### PR TITLE
[BUG] Fixed Player Freeze in Vehicle

### DIFF
--- a/scripts/menu/client/cl_freeze.lua
+++ b/scripts/menu/client/cl_freeze.lua
@@ -27,6 +27,9 @@ end)
 
 RegisterNetEvent('txAdmin:menu:freezePlayer', function(isFrozen)
   debugPrint('Frozen: ' .. tostring(isFrozen))
+	if IsPedInVehicle(PlayerPedId()) then
+     DisableControlAction(0, 23, isFrozen)
+  end
   FreezeEntityPosition(PlayerPedId(), isFrozen)
   sendFreezeAlert(isFrozen)
 end)


### PR DESCRIPTION
- added disable 'f' if a player is in a vehicle. to prevent the player to leave the vehicle.

fix for issue: #463 