### PR TITLE
Fix Routing Problem when Spectating

### DIFF
--- a/scripts/menu/server/sv_player_modal.lua
+++ b/scripts/menu/server/sv_player_modal.lua
@@ -8,6 +8,7 @@ end
 --  related to actions defined within Menu's
 --  "Player Modal"
 -- =============================================
+local oldBucket = 0
 
 RegisterNetEvent('txAdmin:menu:tpToPlayer', function(id)
   local src = source
@@ -71,7 +72,7 @@ RegisterNetEvent('txAdmin:menu:spectatePlayer', function(id)
     local tgtBucket = GetPlayerRoutingBucket(id)
     local srcBucket = GetPlayerRoutingBucket(src)
     if tgtBucket ~= srcBucket then 
-      ADMIN_DATA[tostring(src)].bucket = srcBucket
+      oldBucket = srcBucket
       SetPlayerRoutingBucket(src, tgtBucket)
     end
 
@@ -87,9 +88,9 @@ RegisterNetEvent('txAdmin:menu:endSpectate', function()
   local src = source 
   local allow = PlayerHasTxPermission(src, 'players.spectate')
   if allow then 
-    if ADMIN_DATA[tostring(src)].bucket then 
-      SetPlayerRoutingBucket(src, ADMIN_DATA[tostring(src)].bucket)
-      ADMIN_DATA[tostring(src)].bucket = 0 
-    end
+   
+      SetPlayerRoutingBucket(src, oldBucket)
+oldBucket = 0 
+    
   end
 end)

--- a/scripts/menu/server/sv_player_modal.lua
+++ b/scripts/menu/server/sv_player_modal.lua
@@ -8,7 +8,7 @@ end
 --  related to actions defined within Menu's
 --  "Player Modal"
 -- =============================================
-local oldBucket = 0
+
 
 RegisterNetEvent('txAdmin:menu:tpToPlayer', function(id)
   local src = source
@@ -71,11 +71,10 @@ RegisterNetEvent('txAdmin:menu:spectatePlayer', function(id)
     end
     local tgtBucket = GetPlayerRoutingBucket(id)
     local srcBucket = GetPlayerRoutingBucket(src)
-    if tgtBucket ~= srcBucket then 
-      oldBucket = srcBucket
+   
+      ADMIN_DATA[tostring(src)].bucket = srcBucket
       SetPlayerRoutingBucket(src, tgtBucket)
-    end
-
+   
     local tgtCoords = GetEntityCoords(target)
     TriggerClientEvent('txAdmin:menu:specPlayerResp', src, id, tgtCoords)
   end
@@ -89,8 +88,7 @@ RegisterNetEvent('txAdmin:menu:endSpectate', function()
   local allow = PlayerHasTxPermission(src, 'players.spectate')
   if allow then 
    
-      SetPlayerRoutingBucket(src, oldBucket)
-oldBucket = 0 
+      SetPlayerRoutingBucket(src,  ADMIN_DATA[tostring(src)].bucket)
     
   end
 end)


### PR DESCRIPTION
now, you WILL be set to the target bucket no matter what & it will be saved as your old one.

Also cause it will always be set before spectating, theres no need  to reset my saved old bucket back to 0, cause it always get set to the one, i was in.