### PR TITLE
implemented the ability to change the names of admins via the webpanel

### DIFF
--- a/core/modules/AdminStore/index.js
+++ b/core/modules/AdminStore/index.js
@@ -409,7 +409,7 @@ export default class AdminStore {
      * @param {object|false} [discordData] or false
      * @param {string[]} [permissions]
      */
-    async editAdmin(name, password, citizenfxData, discordData, permissions) {
+    async editAdmin(name, newName, password, citizenfxData, discordData, permissions) {
         if (this.admins == false) throw new Error('Admins not set');
 
         //Find admin index
@@ -418,6 +418,19 @@ export default class AdminStore {
             return (username === user.name.toLowerCase());
         });
         if (adminIndex == -1) throw new Error('Admin not found');
+
+        // Check if name is being changed, if so change the old name to the new one
+        if (newName !== null && newName !== undefined) {
+            // Check if the name is already taken by another admin
+            const nameExists = this.admins.some((admin, index) => {
+                return index !== adminIndex && admin.name.toLowerCase() === newName.toLowerCase();
+            })
+            if (nameExists) {
+                throw new Error("This username is already taken");
+            }
+
+            this.admins[adminIndex].name = newName;
+        }
 
         //Editing admin
         if (password !== null) {

--- a/web/main/adminManager.ejs
+++ b/web/main/adminManager.ejs
@@ -228,6 +228,7 @@
                 $('#modAdmin-body').html(data);
                 if(!name && autofill){
                     $('#modAdmin-name').val(autofill.name);
+                    $('#modAdmin-originalName').val(autofill.name);
                     $('#modAdmin-citizenfxID').val(autofill.citizenfxID);
                     $('#modAdmin-discordID').val(autofill.discordID);
                     autofill = false;
@@ -253,6 +254,7 @@
         });
         const formData = {
             name: $('#modAdmin-name').val().trim(),
+            originalName: $('#modAdmin-originalName').val().trim(),
             citizenfxID: $('#modAdmin-citizenfxID').val().trim(),
             discordID: $('#modAdmin-discordID').val().trim(),
             permissions: (permissions.length)? permissions : false

--- a/web/parts/adminModal.ejs
+++ b/web/parts/adminModal.ejs
@@ -9,7 +9,8 @@
     <div class="col-sm-9">
         <div class="input-group">
             <input type="text" class="form-control" id="modAdmin-name" 
-                value="<%= username %>" <%= isNewAdmin ? 'required' : 'readonly' %>>
+                value="<%= username %>" required>
+            <input type="hidden" id="modAdmin-originalName" value="<%= username %>">
         </div>
     </div>
 </div>


### PR DESCRIPTION
stores the original admin's name in a hidden field, then passes the original name, and name field to the backend
the backend then checks if the name is not equal to the original name, and changes it if so

there's still a "bug" where the notification goes away instantly when updating an admin, but that bug was already there before these changes. I've heard this page was to be redesigned anyways, so didn't bother fixing it.

input is validated on frontend and backend, and admins can't change their own name

example video:

Uploading 0_LocalServer_Admins_and_21_more_pages_-_Profile_1_-_Microsoft_Edge_2025-03-13_21-07-59.mp4…

feature requested in discord:
https://discordapp.com/channels/577993482761928734/1349739764492009472