### PR TITLE
added an option to force admins to use ban templates when banning players

### DIFF
--- a/core/modules/ConfigStore/schema/gameFeatures.ts
+++ b/core/modules/ConfigStore/schema/gameFeatures.ts
@@ -31,6 +31,13 @@ const playerModePtfx = typeDefinedConfig({
     fixer: SYM_FIXER_DEFAULT,
 });
 
+const forceBanTemplates = typeDefinedConfig({
+    name: 'Force Ban Templates',
+    default: false,
+    validator: z.boolean(),
+    fixer: SYM_FIXER_DEFAULT,
+});
+
 const hideAdminInPunishments = typeDefinedConfig({
     name: 'Hide Admin Name In Punishments',
     default: true,
@@ -79,6 +86,7 @@ export default {
     menuAlignRight,
     menuPageKey,
     playerModePtfx,
+    forceBanTemplates,
     hideAdminInPunishments,
     hideAdminInMessages,
     hideDefaultAnnouncement,

--- a/core/modules/WebServer/router.ts
+++ b/core/modules/WebServer/router.ts
@@ -60,6 +60,7 @@ export default () => {
     router.get('/deployer/status', apiAuthMw, routes.deployer_status);
     router.post('/deployer/recipe/:action', apiAuthMw, routes.deployer_actions);
     router.get('/settings/configs', apiAuthMw, routes.settings_getConfigs);
+    router.get('/settings/banTemplates/force', apiAuthMw, routes.settings_getForcedBanTemplates);
     router.post('/settings/configs/:card', apiAuthMw, routes.settings_saveConfigs);
     router.get('/settings/banTemplates', apiAuthMw, routes.settings_getBanTemplates);
     router.post('/settings/banTemplates', apiAuthMw, routes.settings_saveBanTemplates);

--- a/core/routes/index.ts
+++ b/core/routes/index.ts
@@ -31,6 +31,7 @@ export { default as deployer_actions } from './deployer/actions';
 
 //FIXME join bantemplates with settings
 export { default as settings_getConfigs } from './settings/getConfigs';
+export { default as settings_getForcedBanTemplates } from './settings/getForcedBanTemplates';
 export { default as settings_saveConfigs } from './settings/saveConfigs';
 export { default as settings_getBanTemplates } from './banTemplates/getBanTemplates';
 export { default as settings_saveBanTemplates } from './banTemplates/saveBanTemplates';

--- a/core/routes/settings/getForcedBanTemplates.ts
+++ b/core/routes/settings/getForcedBanTemplates.ts
@@ -1,0 +1,23 @@
+const modulename = 'WebServer:GetForcedBanTemplates';
+import consoleFactory from "@lib/console";
+import { AuthedCtx } from "@modules/WebServer/ctxTypes";
+import { GenericApiErrorResp } from "@shared/genericApiTypes";
+const console = consoleFactory(modulename);
+
+export type GetForcedBanTemplatesResp = {
+    forceBanTemplates: boolean,
+}
+
+/**
+ * Returns if the admins are forced to use the ban templates
+ */
+export default async function GetForcedBanTemplates(ctx: AuthedCtx) {
+    const sendTypedResp = (data: GetForcedBanTemplatesResp | GenericApiErrorResp) => ctx.send(data);
+
+    //Prepare data
+    const outData: GetForcedBanTemplatesResp = {
+        forceBanTemplates: txCore.configStore.getStoredConfig().gameFeatures?.forceBanTemplates || false,
+    };
+
+    return sendTypedResp(outData);
+};

--- a/panel/src/layout/PlayerModal/PlayerBanTab.tsx
+++ b/panel/src/layout/PlayerModal/PlayerBanTab.tsx
@@ -6,7 +6,7 @@ import { useRef, useState } from "react";
 import { useBackendApi } from "@/hooks/fetch";
 import { GenericApiOkResp } from "@shared/genericApiTypes";
 import ModalCentralMessage from "@/components/ModalCentralMessage";
-import type { BanTemplatesDataType, GetConfigsResp } from "@shared/otherTypes";
+import type { BanTemplatesDataType, GetForcedBanTemplatesResp,  } from "@shared/otherTypes";
 import BanForm, { BanFormType } from "@/components/BanForm";
 import { txToast } from "@/components/TxToaster";
 import { useEffect } from "react";
@@ -29,9 +29,9 @@ export default function PlayerBanTab({ playerRef, banTemplates }: PlayerBanTabPr
         path: `/player/ban`,
         throwGenericErrors: true,
     });
-    const configApi = useBackendApi<GetConfigsResp>({
+    const forceBanTemplatesApi = useBackendApi<GetForcedBanTemplatesResp>({
         method: 'GET',
-        path: `/settings/configs`,
+        path: `/settings/banTemplates/force`,
         throwGenericErrors: true,
     });
 
@@ -43,10 +43,10 @@ export default function PlayerBanTab({ playerRef, banTemplates }: PlayerBanTabPr
 
     useEffect(() => {
         setIsLoadingConfig(true);
-        configApi({
+        forceBanTemplatesApi({
             success: (data) => {
-                if (data && 'storedConfigs' in data) {
-                    setForceBanTemplates(data.storedConfigs.gameFeatures?.forceBanTemplates === true);
+                if (data && 'forceBanTemplates' in data) {
+                    setForceBanTemplates(data.forceBanTemplates === true);
                 }
                 setIsLoadingConfig(false);
             },

--- a/panel/src/pages/Settings/tabCards/gameMenu.tsx
+++ b/panel/src/pages/Settings/tabCards/gameMenu.tsx
@@ -12,6 +12,7 @@ export const pageConfigs = {
     alignRight: getPageConfig('gameFeatures', 'menuAlignRight'),
     pageKey: getPageConfig('gameFeatures', 'menuPageKey'),
     playerModePtfx: getPageConfig('gameFeatures', 'playerModePtfx'),
+    forceBanTemplates: getPageConfig('gameFeatures', 'forceBanTemplates'),
 } as const;
 
 export default function ConfigCardGameMenu({ cardCtx, pageCtx }: SettingsCardProps) {
@@ -132,6 +133,20 @@ export default function ConfigCardGameMenu({ cardCtx, pageCtx }: SettingsCardPro
                 <SettingItemDesc>
                     Play a particle effect and sound when an admin uses NoClip, God Mode, etc. <br />
                     <strong className="text-warning-inline">Warning:</strong> This options help prevent admin abuse during PvP by making it visible/audible to all players that an admin is using a special mode. We recommend keeping it enabled.
+                </SettingItemDesc>
+            </SettingItem>
+            <SettingItem label="Force Ban Templates" showIf={showAdvanced}>
+                <SwitchText
+                    id={cfg.forceBanTemplates.eid}
+                    checkedLabel="Enabled"
+                    uncheckedLabel="Disabled"
+                    variant="checkedGreen"
+                    checked={states.forceBanTemplates}
+                    onCheckedChange={cfg.forceBanTemplates.state.set}
+                    disabled={pageCtx.isReadOnly}
+                />
+                <SettingItemDesc>
+                    Force the use of ban templates when banning players. Keep in mind this will prevent custom ban reasons and durations.
                 </SettingItemDesc>
             </SettingItem>
         </SettingsCardShell>

--- a/shared/otherTypes.ts
+++ b/shared/otherTypes.ts
@@ -4,6 +4,7 @@ import type { ReactAuthDataType } from "./authApiTypes";
 export type { TxConfigs, PartialTxConfigs } from "@core/modules/ConfigStore/schema";
 export type { ConfigChangelogEntry } from "@core/modules/ConfigStore/changelog";
 export type { GetConfigsResp } from "@core/routes/settings/getConfigs";
+export type { GetForcedBanTemplatesResp } from "@core/routes/settings/getForcedBanTemplates";
 export type { SaveConfigsReq, SaveConfigsResp } from "@core/routes/settings/saveConfigs";
 export type { BanTemplatesDataType, BanDurationType } from "@core/modules/ConfigStore/schema/banlist";
 export type { ResetServerDataPathResp } from "@core/routes/settings/resetServerDataPath";


### PR DESCRIPTION
As requested in #1017

added an optionable toggle under Game > Menu Settings > Show Advanced. It's set to be off by default (maybe this should be 
moved to the Bans tab instead)

did some extensive testing, but please try it out yourself and see if any improvements can be made

Before turning on feature:
![image](https://github.com/user-attachments/assets/84e1b138-d826-48bc-b87e-f741e8cebb16)

Settings page:
![image](https://github.com/user-attachments/assets/33859612-7788-435d-b605-6e6f61c9aab6)

After turning on feature:
![image](https://github.com/user-attachments/assets/a9a730c7-a726-49b4-817c-393bb13022a9)
