### PR TITLE
Option to hide warning when button is disabled.

### DIFF
--- a/resource/cl_main.lua
+++ b/resource/cl_main.lua
@@ -71,7 +71,7 @@ RegisterNetEvent('txcl:showWarning', function(author, reason, actionId, isWarnin
         local count = 0
         while true do
             Wait(100)
-            if IsControlPressed(dismissKeyGroup, dismissKey) then
+            if IsControlPressed(dismissKeyGroup, dismissKey) or IsDisabledControlPressed(dismissKeyGroup, dismissKey) then
                 count = count + 1
                 if count >= countLimit then
                     sendMenuMessage('closeWarning')


### PR DESCRIPTION
In my case, the player who received the warning and was handcuffed couldn't hide it because the handcuff script blocked the control from jumping. :D