### PR TITLE
chore: use secure urls

### DIFF
--- a/dynamicAds.json
+++ b/dynamicAds.json
@@ -4,7 +4,7 @@
             "text": "DDoS protected & preconfigured FiveM txAdmin servers",
             "logoLightMode": "img/zap256_black.png",
             "logoDarkMode": "img/zap256_white.png",
-            "link": "http://zap-hosting.com/txAdmin3"
+            "link": "https://zap-hosting.com/txAdmin3"
         }
     ],
     "main": [
@@ -12,8 +12,8 @@
             "text": "DDoS protected & preconfigured <br> FiveM txAdmin servers",
             "logoLightMode": "img/zap256_black.png",
             "logoDarkMode": "img/zap256_white.png",
-            "linkDesktop": "http://zap-hosting.com/txAdmin5",
-            "linkMobile": "http://zap-hosting.com/txAdmin7"
+            "linkDesktop": "https://zap-hosting.com/txAdmin5",
+            "linkMobile": "https://zap-hosting.com/txAdmin7"
         }
     ],
     "loginZap": [
@@ -21,7 +21,7 @@
             "text": "DDoS protected & preconfigured FiveM txAdmin servers",
             "logoLightMode": "img/zap256_black.png",
             "logoDarkMode": "img/zap256_white.png",
-            "link": "http://zap-hosting.com/txAdmin3"
+            "link": "https://zap-hosting.com/txAdmin3"
         }
     ],
     "mainZap": [
@@ -29,8 +29,8 @@
             "text": "DDoS protected & preconfigured <br> FiveM txAdmin servers",
             "logoLightMode": "img/zap256_black.png",
             "logoDarkMode": "img/zap256_white.png",
-            "linkDesktop": "http://zap-hosting.com/txAdmin5",
-            "linkMobile": "http://zap-hosting.com/txAdmin7"
+            "linkDesktop": "https://zap-hosting.com/txAdmin5",
+            "linkMobile": "https://zap-hosting.com/txAdmin7"
         }
     ]
 }

--- a/dynamicAds2.json
+++ b/dynamicAds2.json
@@ -1,18 +1,18 @@
 {
     "login": {
         "img": "img/zap_login.png",
-        "url": "http://zap-hosting.com/txAdmin3"
+        "url": "https://zap-hosting.com/txAdmin3"
     },
     "main": {
         "img": "img/zap_main.png",
-        "url": "http://zap-hosting.com/txAdmin5"
+        "url": "https://zap-hosting.com/txAdmin5"
     },
     "loginZap": {
         "img": "img/zap_login.png",
-        "url": "http://zap-hosting.com/txAdmin3"
+        "url": "https://zap-hosting.com/txAdmin3"
     },
     "mainZap": {
         "img": "img/zap_main.png",
-        "url": "http://zap-hosting.com/txAdmin5"
+        "url": "https://zap-hosting.com/txAdmin5"
     }
 }


### PR DESCRIPTION
This pull request updates all HTTP links to HTTPS in two JSON files to ensure secure connections. The changes primarily involve replacing `http://` with `https://` in the URLs.

### Security Updates:
* Updated all `http://` links to `https://` in the `dynamicAds.json` file for fields such as `link`, `linkDesktop`, and `linkMobile`.
* Updated all `http://` links to `https://` in the `dynamicAds2.json` file for fields such as `url` under `login`, `main`, `loginZap`, and `mainZap`.