### PR TITLE
fix(menu) Prevent players being able to teleport to themselves

### DIFF
--- a/locale/ar.json
+++ b/locale/ar.json
@@ -302,6 +302,7 @@
                         "spectate_failed": ".فشل في حل الهدف! خروج الطيف",
                         "spectate_yourself": ".لا يمكنك مشاهدة نفسك",
                         "freeze_yourself": ".لا يمكنك تجميد نفسك",
+                        "teleport_yourself": "You cannot teleport to yourself.",
                         "spectate_cycle_failed": ".لا يوجد لاعبين"
                     }
                 },

--- a/locale/bg.json
+++ b/locale/bg.json
@@ -302,6 +302,7 @@
                         "spectate_failed": "Не успешно наблюдаване! Излизане от наблюдение.",
                         "spectate_yourself": "Не можеш да наблюдаваш себе си.",
                         "freeze_yourself": "Не можеш да замръзиш себе си.",
+                        "teleport_yourself": "You cannot teleport to yourself.",
                         "spectate_cycle_failed": "Няма играчи, към които да се движите."
                     }
                 },

--- a/locale/bs.json
+++ b/locale/bs.json
@@ -302,6 +302,7 @@
                         "spectate_failed": "Failed to resolve the target! Exiting spectate.",
                         "spectate_yourself": "You cannot spectate yourself.",
                         "freeze_yourself": "You cannot freeze yourself.",
+                        "teleport_yourself": "You cannot teleport to yourself.",
                         "spectate_cycle_failed": "There are no players to cycle to."
                     }
                 },

--- a/locale/cs.json
+++ b/locale/cs.json
@@ -302,6 +302,7 @@
                         "spectate_failed": "Nepodařilo se udržet signál pozorování! Vypínám pozorování.",
                         "spectate_yourself": "Nemůžeš pozorovat sebe.",
                         "freeze_yourself": "Nemůžeš zmrazit sebe.",
+                        "teleport_yourself": "You cannot teleport to yourself.",
                         "spectate_cycle_failed": "Žádní dostupní hráči, na které by se dalo přepnout."
                     }
                 },

--- a/locale/da.json
+++ b/locale/da.json
@@ -302,6 +302,7 @@
                         "spectate_failed": "Det lykkedes ikke at overvåge målet! Stopper overvågning.",
                         "spectate_yourself": "Du kan ikke overvåge dig selv.",
                         "freeze_yourself": "Du kan ikke fryse dig selv.",
+                        "teleport_yourself": "You cannot teleport to yourself.",
                         "spectate_cycle_failed": "Der er ikke flere spillere på rotationen."
                     }
                 },

--- a/locale/de.json
+++ b/locale/de.json
@@ -302,6 +302,7 @@
                         "spectate_failed": "Der Spieler konnte nicht beobachtet werden! Beobachtung abgebrochen.",
                         "spectate_yourself": "Du kannst dich nicht selbst beobachten",
                         "freeze_yourself": "Du kannst dich nicht selbst einfrieren",
+                        "teleport_yourself": "You cannot teleport to yourself.",
                         "spectate_cycle_failed": "Es gibt keine Spieler auf die gewechselt werden kann."
                     }
                 },

--- a/locale/el.json
+++ b/locale/el.json
@@ -302,6 +302,7 @@
                         "spectate_failed": "Failed to resolve the target! Exiting spectate.",
                         "spectate_yourself": "You cannot spectate yourself.",
                         "freeze_yourself": "You cannot freeze yourself.",
+                        "teleport_yourself": "You cannot teleport to yourself.",
                         "spectate_cycle_failed": "There are no players to cycle to."
                     }
                 },

--- a/locale/en.json
+++ b/locale/en.json
@@ -302,6 +302,7 @@
                         "spectate_failed": "Failed to resolve the target! Exiting spectate.",
                         "spectate_yourself": "You cannot spectate yourself.",
                         "freeze_yourself": "You cannot freeze yourself.",
+                        "teleport_yourself": "You cannot teleport to yourself.",
                         "spectate_cycle_failed": "There are no players to cycle to."
                     }
                 },

--- a/locale/es.json
+++ b/locale/es.json
@@ -302,6 +302,7 @@
                         "spectate_failed": "¡No se pudo encontrar al objetivo! Saliendo de observar.",
                         "spectate_yourself": "No te puedes observar a ti mismo.",
                         "freeze_yourself": "No te puedes congelar a ti mismo.",
+                        "teleport_yourself": "You cannot teleport to yourself.",
                         "spectate_cycle_failed": "There are no players to cycle to."
                     }
                 },

--- a/locale/et.json
+++ b/locale/et.json
@@ -302,6 +302,7 @@
                         "spectate_failed": "Eesmärki ei õnnestunud lahendada! Lahkun Specatatest.",
                         "spectate_yourself": "Sa ei saa ennast specateda.",
                         "freeze_yourself": "Te ei saa ennast külmutada.",
+                        "teleport_yourself": "You cannot teleport to yourself.",
                         "spectate_cycle_failed": "There are no players to cycle to."
                     }
                 },

--- a/locale/fa.json
+++ b/locale/fa.json
@@ -302,6 +302,7 @@
                         "spectate_failed": "Failed to resolve the target! Exiting spectate.",
                         "spectate_yourself": "You cannot spectate yourself.",
                         "freeze_yourself": "You cannot freeze yourself.",
+                        "teleport_yourself": "You cannot teleport to yourself.",
                         "spectate_cycle_failed": "There are no players to cycle to."
                     }
                 },

--- a/locale/fi.json
+++ b/locale/fi.json
@@ -302,6 +302,7 @@
                         "spectate_failed": "Virhe kohteen tavoittamisessa!",
                         "spectate_yourself": "Et voi katsoa itseäsi.",
                         "freeze_yourself": "Et voi jäädyttää itseäsi.",
+                        "teleport_yourself": "You cannot teleport to yourself.",
                         "spectate_cycle_failed": "There are no players to cycle to."
                     }
                 },

--- a/locale/fr.json
+++ b/locale/fr.json
@@ -302,6 +302,7 @@
                         "spectate_failed": "Impossible de trouver le joueur ! Désactivation du mode surveillance.",
                         "spectate_yourself": "Vous ne pouvez pas vous surveiller vous-même.",
                         "freeze_yourself": "Vous ne pouvez pas vous geler vous-même.",
+                        "teleport_yourself": "You cannot teleport to yourself.",
                         "spectate_cycle_failed": "Il n'y a pas de joueurs vers lesquels faire du vélo."
                     }
                 },

--- a/locale/hr.json
+++ b/locale/hr.json
@@ -302,6 +302,7 @@
                         "spectate_failed": "Neuspješno dohvaćanje igrača! Izlaženje iz gledanja.",
                         "spectate_yourself": "Ne možeš sam sebe gledat.",
                         "freeze_yourself": "Ne možeš sam sebe zalediti.",
+                        "teleport_yourself": "You cannot teleport to yourself.",
                         "spectate_cycle_failed": "Nema igrača koje bi gledao."
                     }
                 },

--- a/locale/hu.json
+++ b/locale/hu.json
@@ -302,6 +302,7 @@
                         "spectate_failed": "Hiba a játékos megfigyelésénél! Kilépés a megfigyelésből.",
                         "spectate_yourself": "Magadat nem figyelheted meg.",
                         "freeze_yourself": "Magadat nem fagyaszthatod le.",
+                        "teleport_yourself": "You cannot teleport to yourself.",
                         "spectate_cycle_failed": "Nincs megfigyelhető játékos."
                     }
                 },

--- a/locale/id.json
+++ b/locale/id.json
@@ -302,6 +302,7 @@
                         "spectate_failed": "Pemain tidak ditemukan.",
                         "spectate_yourself": "Anda tidak dapat memantau diri sendiri.",
                         "freeze_yourself": "Anda tidak dapat membekukan diri sendiri.",
+                        "teleport_yourself": "You cannot teleport to yourself.",
                         "spectate_cycle_failed": "Tidak ada pemain lain yang dapat dipantau."
                     }
                 },

--- a/locale/it.json
+++ b/locale/it.json
@@ -302,6 +302,7 @@
                         "spectate_failed": "Impossibile risolvere il bersaglio! Uscendo dallo Spectate.",
                         "spectate_yourself": "Non puoi spectarti da solo.",
                         "freeze_yourself": "Non puoi freezarti da solo.",
+                        "teleport_yourself": "You cannot teleport to yourself.",
                         "spectate_cycle_failed": "There are no players to cycle to."
                     }
                 },

--- a/locale/ja.json
+++ b/locale/ja.json
@@ -302,6 +302,7 @@
                         "spectate_failed": "ターゲットの解決に失敗しました!観戦を終了します",
                         "spectate_yourself": "自分自身は観戦できない",
                         "freeze_yourself": "自分自身を静止することはできない",
+                        "teleport_yourself": "You cannot teleport to yourself.",
                         "spectate_cycle_failed": "切り替えられる他のプレイヤーがいない"
                     }
                 },

--- a/locale/lt.json
+++ b/locale/lt.json
@@ -302,6 +302,7 @@
                         "spectate_failed": "Žaidėjas nerastas! Stebėjimas išjungiamas.",
                         "spectate_yourself": "Negalite stebėti savęs.",
                         "freeze_yourself": "Negalite užšaldyti savęs.",
+                        "teleport_yourself": "You cannot teleport to yourself.",
                         "spectate_cycle_failed": "Nėra kitų žaidėjų"
                     }
                 },

--- a/locale/lv.json
+++ b/locale/lv.json
@@ -302,6 +302,7 @@
                         "spectate_failed": "Neizdevās atrast spēlētāju! Beidz vērošanu.",
                         "spectate_yourself": "Tu nevari vērot sevi.",
                         "freeze_yourself": "Tu nevari iesaldēt sevi.",
+                        "teleport_yourself": "You cannot teleport to yourself.",
                         "spectate_cycle_failed": "Nav neviena cita spēlētāja, ko vērot."
                     }
                 },

--- a/locale/mn.json
+++ b/locale/mn.json
@@ -302,6 +302,7 @@
                         "spectate_failed": "Зорилгоо шийдэж чадсангүй! Үзэсгэлэнгээс гарах.",
                         "spectate_yourself": "Та өөрийгөө харж чадахгүй.",
                         "freeze_yourself": "Та өөрийгөө хөлдөөж чадахгүй.",
+                        "teleport_yourself": "You cannot teleport to yourself.",
                         "spectate_cycle_failed": "Өөр тоглогч байхгүй."
                     }
                 },

--- a/locale/ne.json
+++ b/locale/ne.json
@@ -302,6 +302,7 @@
                         "spectate_failed": "लक्ष्य समाधान गर्न असफल! निगरानी बाहिर निस्कँदै।",
                         "spectate_yourself": "तपाईं आफैंलाई निगरानी गर्न सक्नुहुन्न।",
                         "freeze_yourself": "तपाईं आफैंलाई जमाउन सक्नुहुन्न।",
+                        "teleport_yourself": "You cannot teleport to yourself.",
                         "spectate_cycle_failed": "साइकल गर्न कुनै खेलाडीहरू छैनन्।"
                     }
                 },

--- a/locale/nl.json
+++ b/locale/nl.json
@@ -302,6 +302,7 @@
                         "spectate_failed": "Kon de speler niet vinden! Spectate aan het afsluiten.",
                         "spectate_yourself": "Je kan jezelf niet spectaten.",
                         "freeze_yourself": "Je kan jezelf niet freezen.",
+                        "teleport_yourself": "Je kan niet naar jezelf teleporteren.",
                         "spectate_cycle_failed": "Er zijn geen spelers om naar door te cyclen."
                     }
                 },

--- a/locale/no.json
+++ b/locale/no.json
@@ -302,6 +302,7 @@
                         "spectate_failed": "Failed to resolve the target! Exiting spectate.",
                         "spectate_yourself": "You cannot spectate yourself.",
                         "freeze_yourself": "You cannot freeze yourself.",
+                        "teleport_yourself": "You cannot teleport to yourself.",
                         "spectate_cycle_failed": "There are no players to cycle to."
                     }
                 },

--- a/locale/pl.json
+++ b/locale/pl.json
@@ -302,6 +302,7 @@
                         "spectate_failed": "Nie udało się rozwiązać celu! Wyjście z Obserwacji.",
                         "spectate_yourself": "Nie możesz obserwować samego siebie.",
                         "freeze_yourself": "Nie możesz zamrozić samego siebie.",
+                        "teleport_yourself": "You cannot teleport to yourself.",
                         "spectate_cycle_failed": "Nie ma już więcej graczy do obserwowania."
                     }
                 },

--- a/locale/pt.json
+++ b/locale/pt.json
@@ -302,6 +302,7 @@
                         "spectate_failed": "Erro ao resolver o alvo! Cancelando modo observar.",
                         "spectate_yourself": "Você não pode observar você mesmo.",
                         "freeze_yourself": "Você não pode congelar você mesmo.",
+                        "teleport_yourself": "You cannot teleport to yourself.",
                         "spectate_cycle_failed": "Não há mais players para observar."
                     }
                 },

--- a/locale/ro.json
+++ b/locale/ro.json
@@ -302,6 +302,7 @@
                         "spectate_failed": "Nu a reușit comunicarea cu jucătorul! Ieșire din spectatori.",
                         "spectate_yourself": "Nu poți fi spectator tu însuți.",
                         "freeze_yourself": "Nu te poți îngheța.",
+                        "teleport_yourself": "You cannot teleport to yourself.",
                         "spectate_cycle_failed": "There are no players to cycle to."
                     }
                 },

--- a/locale/ru.json
+++ b/locale/ru.json
@@ -302,6 +302,7 @@
                         "spectate_failed": "Не удалось найти цель! Выходим из наблюдения.",
                         "spectate_yourself": "Вы не можете наблюдать за самим собой.",
                         "freeze_yourself": "Вы не можете заморозить себя.",
+                        "teleport_yourself": "You cannot teleport to yourself.",
                         "spectate_cycle_failed": "Нет игроков, к которым можно переключиться."
                     }
                 },

--- a/locale/sl.json
+++ b/locale/sl.json
@@ -302,6 +302,7 @@
                         "spectate_failed": "Igralca več ni bilo mogoče najti! Izstopam iz Spectate načina.",
                         "spectate_yourself": "Ne moreš spectate-at sam sebe.",
                         "freeze_yourself": "Sam sebe ne moreš zamrzniti.",
+                        "teleport_yourself": "You cannot teleport to yourself.",
                         "spectate_cycle_failed": "Ni igralca, na katerega bi lahko preklopili."
                     }
                 },

--- a/locale/sv.json
+++ b/locale/sv.json
@@ -302,6 +302,7 @@
                         "spectate_failed": "Misslyckades att hitta spelaren, avslutar åskådarläget.",
                         "spectate_yourself": "Du kan inte åskåda dig själv.",
                         "freeze_yourself": "Du kan inte frysa dig själv.",
+                        "teleport_yourself": "You cannot teleport to yourself.",
                         "spectate_cycle_failed": "Där finns inga spelare att gå mellan."
                     }
                 },

--- a/locale/th.json
+++ b/locale/th.json
@@ -302,6 +302,7 @@
                         "spectate_failed": "ล้มเหลวในการไปหาเป้าหมาย ออกจากโหมดรับชม",
                         "spectate_yourself": "คุณไม่สามารถรับชมตัวเองได้",
                         "freeze_yourself": "คุณไม่สามารถระงับตัวเองได้",
+                        "teleport_yourself": "You cannot teleport to yourself.",
                         "spectate_cycle_failed": "There are no players to cycle to."
                     }
                 },

--- a/locale/tr.json
+++ b/locale/tr.json
@@ -302,6 +302,7 @@
                         "spectate_failed": "Hedef çözülemedi! İzlemeden çıkıldı.",
                         "spectate_yourself": "Kendini izleyemezsiniz.",
                         "freeze_yourself": "Kendini donduramazsın.",
+                        "teleport_yourself": "You cannot teleport to yourself.",
                         "spectate_cycle_failed": "There are no players to cycle to."
                     }
                 },

--- a/locale/uk.json
+++ b/locale/uk.json
@@ -302,6 +302,7 @@
                         "spectate_failed": "Не вдалося визначити ціль! Завершення спостереження.",
                         "spectate_yourself": "Ви не можете спостерігати за собою.",
                         "freeze_yourself": "Ви не можете заморозити себе.",
+                        "teleport_yourself": "You cannot teleport to yourself.",
                         "spectate_cycle_failed": "Немає гравців для циклу спостереження."
                     }
                 },

--- a/locale/vi.json
+++ b/locale/vi.json
@@ -302,6 +302,7 @@
                         "spectate_failed": "Có lỗi khi thực hiện theo dõi, đang thoát chế độ theo dõi.",
                         "spectate_yourself": "Bạn không thể tự theo dõi chính mình.",
                         "freeze_yourself": "Bạn không thể tự đóng băng bản thân!",
+                        "teleport_yourself": "You cannot teleport to yourself.",
                         "spectate_cycle_failed": "Không có người chơi để đạp xe đến."
                     }
                 },

--- a/locale/zh.json
+++ b/locale/zh.json
@@ -302,6 +302,7 @@
                         "spectate_failed": "无法解析目标！正在退出观看，",
                         "spectate_yourself": "您不能观看您自己",
                         "freeze_yourself": "您不能冻结您自己",
+                        "teleport_yourself": "You cannot teleport to yourself.",
                         "spectate_cycle_failed": "没有可循环的玩家"
                     }
                 },

--- a/nui/src/components/PlayerModal/Tabs/DialogActionView.tsx
+++ b/nui/src/components/PlayerModal/Tabs/DialogActionView.tsx
@@ -225,11 +225,15 @@ const DialogActionView: React.FC = () => {
     }
 
     closeMenu();
-    fetchNui("tpToPlayer", { id: assocPlayer.id });
-    enqueueSnackbar(
-      t("nui_menu.player_modal.actions.interaction.notifications.tp_player"),
-      { variant: "success" }
-    );
+    fetchNui("tpToPlayer", { id: assocPlayer.id }).then(({ success }) => {
+
+      if (success) {
+        return enqueueSnackbar(t("nui_menu.player_modal.actions.interaction.notifications.tp_player"), {
+          variant: "success"
+        });
+      }
+    });
+
   };
 
   const handleBring = () => {
@@ -242,7 +246,7 @@ const DialogActionView: React.FC = () => {
         variant: "error",
       });
     }
-    
+
     closeMenu();
     fetchNui("summonPlayer", { id: assocPlayer.id });
     enqueueSnackbar(

--- a/resource/menu/client/cl_main_page.lua
+++ b/resource/menu/client/cl_main_page.lua
@@ -58,6 +58,13 @@ end)
 
 
 RegisterSecureNuiCallback('tpToPlayer', function(data, cb)
+    local targetServerId = tonumber(data.id)
+
+    -- check for self-teleport
+    if targetServerId == GetPlayerServerId(PlayerId()) then
+        return sendSnackbarMessage('error', 'nui_menu.player_modal.actions.interaction.notifications.teleport_yourself', true)
+    end
+
     TriggerServerEvent('txsv:req:tpToPlayer', tonumber(data.id))
     cb({})
 end)


### PR DESCRIPTION
This PR adds a check to the "GO TO" option in the menu to prevent users from teleporting to themselves 

Preview:

https://r2.fivemanage.com/KFTFxoppLJfPvAgnQBsLL/teleportToSelf.gif
