### PR TITLE
fix(menu) Fix playernames with invalid chars in name

### DIFF
--- a/resource/menu/client/cl_player_ids.lua
+++ b/resource/menu/client/cl_player_ids.lua
@@ -130,7 +130,8 @@ local function showGamerTags()
             or not IsMpGamerTagActive(playerGamerTags[pid].gamerTag)
         then
             local playerName = string.sub(GetPlayerName(pid) or "unknown", 1, 75)
-            local playerStr = '[' .. GetPlayerServerId(pid) .. ']' .. ' ' .. playerName
+            local convertedPlayerName = string.gsub(playerName, "[^%w_]", "")
+            local playerStr = '[' .. GetPlayerServerId(pid) .. ']' .. ' ' .. convertedPlayerName
             playerGamerTags[pid] = {
                 gamerTag = CreateFakeMpGamerTag(targetPed, playerStr, false, false, 0),
                 ped = targetPed


### PR DESCRIPTION
there are some chars when you have that in your name, the name will no longer be shown at all.
The pr will remove the invalid char.

**Preview:**
![image](https://github.com/user-attachments/assets/86c99ff4-1153-4e7d-ba4a-d339d87eced7)

**Player name:**
![image](https://github.com/user-attachments/assets/4ec1ac18-b3b3-4fa9-9edd-fe082ad856dc)
