### PR TITLE
feat(discord): implement Discord API helper for member and role resolution

### DIFF
--- a/core/modules/DiscordBot/discordApiHelper.ts
+++ b/core/modules/DiscordBot/discordApiHelper.ts
@@ -1,0 +1,175 @@
+const modulename = 'DiscordApiHelper';
+import consoleFactory from '@lib/console';
+const console = consoleFactory(modulename);
+
+const DISCORD_API_BASE = 'https://discord.com/api/v10';
+
+export type DiscordMemberResult = {
+    isMember: boolean;
+    memberRoles?: string[];
+    error?: string;
+};
+
+export type DiscordUserProfile = {
+    tag: string;
+    avatar?: string;
+};
+
+/**
+ * Lightweight Discord API helper for member/role resolution
+ * Uses HTTP API directly without requiring a full Discord bot client
+ */
+export class DiscordApiHelper {
+    private token: string;
+    private guildId: string;
+    private headers: Record<string, string>;
+    private guildName?: string;
+    private memberCache = new Map<string, { timestamp: number; data: DiscordMemberResult }>();
+    private readonly CACHE_TTL = 60_000; // 1 minute cache
+
+    constructor(token: string, guildId: string) {
+        this.token = token;
+        this.guildId = guildId;
+        this.headers = {
+            'Authorization': `Bot ${token}`,
+            'Content-Type': 'application/json',
+        };
+        this.fetchGuildInfo();
+    }
+
+    /**
+     * Fetches basic guild information
+     */
+    private async fetchGuildInfo() {
+        try {
+            const response = await fetch(`${DISCORD_API_BASE}/guilds/${this.guildId}`, {
+                headers: this.headers
+            });
+            
+            if (response.ok) {
+                const guild = await response.json();
+                this.guildName = guild.name;
+            }
+        } catch (error) {
+            console.warn(`Failed to fetch guild info: ${(error as Error).message}`);
+        }
+    }
+
+    /**
+     * Get guild name
+     */
+    getGuildName(): string | undefined {
+        return this.guildName;
+    }
+
+    /**
+     * Check if a user is a member of the guild and get their roles
+     */
+    async resolveMemberRoles(userId: string): Promise<DiscordMemberResult> {
+        // Check cache first
+        const cached = this.memberCache.get(userId);
+        if (cached && Date.now() - cached.timestamp < this.CACHE_TTL) {
+            return cached.data;
+        }
+
+        try {
+            const response = await fetch(`${DISCORD_API_BASE}/guilds/${this.guildId}/members/${userId}`, {
+                headers: this.headers
+            });
+
+            if (response.status === 404) {
+                const result = { isMember: false };
+                this.memberCache.set(userId, { timestamp: Date.now(), data: result });
+                return result;
+            }
+
+            if (!response.ok) {
+                throw new Error(`Discord API returned ${response.status}: ${response.statusText}`);
+            }
+
+            const member = await response.json();
+            const result = {
+                isMember: true,
+                memberRoles: member.roles as string[]
+            };
+            
+            this.memberCache.set(userId, { timestamp: Date.now(), data: result });
+            return result;
+        } catch (error) {
+            console.verbose.error(`Failed to resolve Discord member ${userId}: ${(error as Error).message}`);
+            return {
+                isMember: false,
+                error: (error as Error).message
+            };
+        }
+    }
+
+    /**
+     * Get user profile information (tag and avatar)
+     */
+    async resolveMemberProfile(userId: string): Promise<DiscordUserProfile | null> {
+        try {
+            const response = await fetch(`${DISCORD_API_BASE}/users/${userId}`, {
+                headers: this.headers
+            });
+
+            if (!response.ok) {
+                throw new Error(`Discord API returned ${response.status}: ${response.statusText}`);
+            }
+
+            const user = await response.json();
+            const tag = user.discriminator === '0' 
+                ? `@${user.username}`
+                : `${user.username}#${user.discriminator}`;
+            
+            return {
+                tag,
+                avatar: user.avatar 
+                    ? `https://cdn.discordapp.com/avatars/${user.id}/${user.avatar}.png`
+                    : undefined
+            };
+        } catch (error) {
+            console.verbose.error(`Failed to resolve Discord user profile ${userId}: ${(error as Error).message}`);
+            return null;
+        }
+    }
+
+    /**
+     * Clear member cache
+     */
+    clearCache() {
+        this.memberCache.clear();
+    }
+}
+
+// Global instance for Discord API helper
+let discordApiHelper: DiscordApiHelper | null = null;
+
+/**
+ * Get or create Discord API helper instance
+ */
+export function getDiscordApiHelper(): DiscordApiHelper | null {
+    // Only create if we have Discord whitelist enabled and credentials
+    if (
+        (txConfig.whitelist.mode === 'discordMember' || txConfig.whitelist.mode === 'discordRoles')
+        && txConfig.discordBot.token
+        && txConfig.discordBot.guild
+    ) {
+        if (!discordApiHelper || 
+            discordApiHelper['token'] !== txConfig.discordBot.token ||
+            discordApiHelper['guildId'] !== txConfig.discordBot.guild
+        ) {
+            discordApiHelper = new DiscordApiHelper(
+                txConfig.discordBot.token,
+                txConfig.discordBot.guild
+            );
+        }
+        return discordApiHelper;
+    }
+    
+    // Clear helper if not needed
+    if (discordApiHelper) {
+        discordApiHelper = null;
+    }
+    return null;
+}

--- a/core/routes/player/checkJoin.ts
+++ b/core/routes/player/checkJoin.ts
@@ -11,6 +11,7 @@ import humanizeDuration, { Unit } from 'humanize-duration';
 import consoleFactory from '@lib/console';
 import { TimeCounter } from '@modules/Metrics/statsUtils';
 import { InitializedCtx } from '@modules/WebServer/ctxTypes';
+import { getDiscordApiHelper } from '@modules/DiscordBot/discordApiHelper';
 const console = consoleFactory(modulename);
 const xss = xssInstancer();
 
@@ -294,7 +295,9 @@ async function checkDiscordMember(
     validIdsObject: PlayerIdsObjectType,
     playerName: string
 ): Promise<AllowRespType | DenyRespType> {
-    const guildname = `<guildname>${txCore.discordBot.guildName}</guildname>`;
+    const discordApi = getDiscordApiHelper();
+    const guildName = discordApi?.getGuildName() || txCore.discordBot?.guildName || 'Discord Server';
+    const guildname = `<guildname>${guildName}</guildname>`;
     const textKeys = {
         mode_title: txCore.translator.t('whitelist_messages.guild_member.mode_title'),
         insufficient_ids: txCore.translator.t('whitelist_messages.guild_member.insufficient_ids'),
@@ -316,8 +319,11 @@ async function checkDiscordMember(
     //Resolving member
     let errorTitle, errorMessage;
     try {
-        const { isMember, memberRoles } = await txCore.discordBot.resolveMemberRoles(validIdsObject.discord);
-        if (isMember) {
+        const result = discordApi 
+            ? await discordApi.resolveMemberRoles(validIdsObject.discord)
+            : await txCore.discordBot.resolveMemberRoles(validIdsObject.discord);
+        
+        if (result.isMember) {
             return { allow: true };
         } else {
             errorTitle = textKeys.deny_title;
@@ -346,7 +352,9 @@ async function checkDiscordRoles(
     validIdsObject: PlayerIdsObjectType,
     playerName: string
 ): Promise<AllowRespType | DenyRespType> {
-    const guildname = `<guildname>${txCore.discordBot.guildName}</guildname>`;
+    const discordApi = getDiscordApiHelper();
+    const guildName = discordApi?.getGuildName() || txCore.discordBot?.guildName || 'Discord Server';
+    const guildname = `<guildname>${guildName}</guildname>`;
     const textKeys = {
         mode_title: txCore.translator.t('whitelist_messages.guild_roles.mode_title'),
         insufficient_ids: txCore.translator.t('whitelist_messages.guild_roles.insufficient_ids'),
@@ -370,10 +378,13 @@ async function checkDiscordRoles(
     //Resolving member
     let errorTitle, errorMessage;
     try {
-        const { isMember, memberRoles } = await txCore.discordBot.resolveMemberRoles(validIdsObject.discord);
-        if (isMember) {
+        const result = discordApi 
+            ? await discordApi.resolveMemberRoles(validIdsObject.discord)
+            : await txCore.discordBot.resolveMemberRoles(validIdsObject.discord);
+        
+        if (result.isMember) {
             const matchingRole = txConfig.whitelist.discordRoles
-                .find((requiredRole) => memberRoles?.includes(requiredRole));
+                .find((requiredRole) => result.memberRoles?.includes(requiredRole));
             if (matchingRole) {
                 return { allow: true };
             } else {
@@ -475,11 +486,20 @@ async function checkApprovedLicense(
     //Player is not whitelisted
     //Resolve player discord
     let discordTag, discordAvatar;
-    if (validIdsObject.discord && txCore.discordBot.isClientReady) {
+    if (validIdsObject.discord) {
         try {
-            const { tag, avatar } = await txCore.discordBot.resolveMemberProfile(validIdsObject.discord);
-            discordTag = tag;
-            discordAvatar = avatar;
+            const discordApi = getDiscordApiHelper();
+            if (discordApi) {
+                const profile = await discordApi.resolveMemberProfile(validIdsObject.discord);
+                if (profile) {
+                    discordTag = profile.tag;
+                    discordAvatar = profile.avatar;
+                }
+            } else if (txCore.discordBot?.isClientReady) {
+                const { tag, avatar } = await txCore.discordBot.resolveMemberProfile(validIdsObject.discord);
+                discordTag = tag;
+                discordAvatar = avatar;
+            }
         } catch (error) { }
     }
 

--- a/core/routes/settings/saveConfigs.ts
+++ b/core/routes/settings/saveConfigs.ts
@@ -311,9 +311,43 @@ const handleDiscordCard: CardHandler = async (inputConfig, sendTypedResp) => {
         }
     }
 
-    //If bot disabled, kill the bot and don't validate anything
+    //If bot disabled, kill the bot but check if we need credentials for whitelist
     if (!inputConfig.discordBot?.enabled) {
         await txCore.discordBot.attemptBotReset(false);
+        
+        // Check if Discord-based whitelist is enabled
+        const isDiscordWhitelistNeeded = (
+            txConfig.whitelist.mode === 'discordMember' || 
+            txConfig.whitelist.mode === 'discordRoles'
+        );
+        
+        // If Discord whitelist is enabled, validate required credentials
+        if (isDiscordWhitelistNeeded) {
+            const schemas = ConfigStore.Schema.discordBot;
+            const validationError = getSchemaChainError([
+                [schemas.token, inputConfig.discordBot.token],
+                [schemas.guild, inputConfig.discordBot.guild],
+            ]);
+            if (validationError) {
+                return sendTypedResp({
+                    type: 'error',
+                    title: 'Discord Credentials Required for Whitelist',
+                    md: true,
+                    msg: 'Discord Token and Guild ID are required for Discord-based whitelist modes, even with Discord Bot commands disabled.\n\n' + validationError,
+                });
+            }
+            
+            // Check if required fields are present
+            if (!inputConfig.discordBot.token || !inputConfig.discordBot.guild) {
+                return sendTypedResp({
+                    type: 'error',
+                    title: 'Discord Credentials Required for Whitelist',
+                    md: true,
+                    msg: 'Discord Token and Guild ID are required for Discord-based whitelist modes, even with Discord Bot commands disabled.',
+                });
+            }
+        }
+        
         return { processedConfig: inputConfig };
     }
 

--- a/panel/src/pages/Settings/tabCards/whitelist.tsx
+++ b/panel/src/pages/Settings/tabCards/whitelist.tsx
@@ -78,10 +78,10 @@ export default function ConfigCardWhitelist({ cardCtx, pageCtx }: SettingsCardPr
             localConfigs.whitelist?.mode === 'discordMember'
             || localConfigs.whitelist?.mode === 'discordRoles'
         ) {
-            if (pageCtx.apiData?.storedConfigs.discordBot?.enabled !== true) {
+            if (!pageCtx.apiData?.storedConfigs.discordBot?.token || !pageCtx.apiData?.storedConfigs.discordBot?.guild) {
                 return txToast.warning({
-                    title: 'Discord Bot is required.',
-                    msg: 'You need to enable the Discord Bot in the Discord tab to use Discord-based whitelist modes.',
+                    title: 'Discord credentials required.',
+                    msg: 'You need to provide a Discord Bot Token and Guild ID in the Discord tab to use Discord-based whitelist modes. The Discord Bot can remain disabled.',
                 });
             }
             if (
@@ -143,7 +143,7 @@ export default function ConfigCardWhitelist({ cardCtx, pageCtx }: SettingsCardPr
                         value="discordMember"
                         title="Discord Server Member"
                         desc={(<>
-                            Checks if the player joining has a <InlineCode>discord:</InlineCode> identifier and is present in the Discord server configured in the Discord Tab.
+                            Checks if the player joining has a <InlineCode>discord:</InlineCode> identifier and is present in the Discord server configured in the Discord Tab. Only requires Discord Bot Token and Guild ID (Discord Bot can remain disabled).
                         </>)}
                     />
                     <BigRadioItem
@@ -151,7 +151,7 @@ export default function ConfigCardWhitelist({ cardCtx, pageCtx }: SettingsCardPr
                         value="discordRoles"
                         title="Discord Server Roles"
                         desc={(<>
-                            Checks if the player joining has a <InlineCode>discord:</InlineCode> identifier and is present in the Discord server configured in the Discord Tab and has at least one of the roles specified below.
+                            Checks if the player joining has a <InlineCode>discord:</InlineCode> identifier and is present in the Discord server configured in the Discord Tab and has at least one of the roles specified below. Only requires Discord Bot Token and Guild ID (Discord Bot can remain disabled).
                         </>)}
                     />
                     <BigRadioItem


### PR DESCRIPTION
## Summary
Implements a lightweight Discord API helper that uses direct HTTP requests instead of requiring a full Discord bot client, allowing Discord whitelist functionality without token conflicts.

## Problem Solved
Previously, using Discord whitelist features required `discordBot.enabled = true`, which created a Discord.js client with websocket connection. This caused token conflicts when users already had their own Discord bot running on the same token, since Discord only allows one bot connection per token.

## Solution
- **New Discord API Helper** (`core/modules/DiscordBot/discordApiHelper.ts`)
  - Uses raw Discord REST API calls via HTTP instead of websocket connection
  - Handles member resolution by ID with role checking
  - Includes 1-minute caching to reduce API calls
  - Only activated when Discord whitelist modes are enabled
  - No persistent connection - only makes requests when needed

## Changes
- **Enhanced Player Join Checks** (`core/routes/player/checkJoin.ts`)
  - Integrated Discord API helper for whitelist validation
  - Uses HTTP API calls instead of Discord.js client methods
- **Settings Configuration** (`core/routes/settings/saveConfigs.ts`)
  - Enhanced Discord configuration validation
  - Better handling of Discord API helper initialization
- **Frontend Whitelist UI** (`panel/src/pages/Settings/tabCards/whitelist.tsx`)
  - Minor UI improvements for Discord whitelist configuration

## Key Benefits
- **No Token Conflicts**: Users can run their own Discord bots while using txAdmin's Discord whitelist
- **Lightweight**: Only makes HTTP requests when checking player joins
- **Backwards Compatible**: Existing Discord whitelist configurations continue working
- **Better Performance**: Cached member lookups reduce redundant API calls

## Technical Details
The helper automatically activates when `whitelist.mode` is set to `discordMember` or `discordRoles` and Discord credentials are configured, regardless of `discordBot.enabled` status. This allows Discord whitelist functionality without requiring the full bot client.