### PR TITLE
feat(discord) Add maintenance mode status to discord bot embed

### DIFF
--- a/core/modules/DiscordBot/commands/status.ts
+++ b/core/modules/DiscordBot/commands/status.ts
@@ -93,13 +93,10 @@ export const generateStatusMessage = (
     }
 
     //Prepare status placeholders
-    if (txConfig.whitelist.mode === 'adminOnly') {
-        placeholders.statusString = embedConfigJson?.maintenanceString ?? '🟠 Maintenance';
-        placeholders.statusColor = embedConfigJson?.maintenanceColor ?? "#FD8C4C";
-    }
-    else if (fxMonitorStatus.health === FxMonitorHealth.ONLINE) {
-        placeholders.statusString = embedConfigJson?.onlineString ?? '🟢 Online';
-        placeholders.statusColor = embedConfigJson?.onlineColor ?? "#0BA70B";
+    if (fxMonitorStatus.health === FxMonitorHealth.ONLINE) {
+        const isAdminOnly = txConfig.whitelist.mode === 'adminOnly';
+        placeholders.statusString = isAdminOnly ? embedConfigJson?.maintenanceString ?? '🟠 Maintenance' : embedConfigJson?.onlineString ?? '🟢 Online';
+        placeholders.statusColor = isAdminOnly ? embedConfigJson?.maintenanceColor ?? "#FD8C4C" : embedConfigJson?.onlineColor ?? "#0BA70B";
     } else if (fxMonitorStatus.health === FxMonitorHealth.PARTIAL) {
         placeholders.statusString = embedConfigJson?.partialString ?? '🟡 Partial';
         placeholders.statusColor = embedConfigJson?.partialColor ?? "#FFF100";

--- a/core/modules/DiscordBot/commands/status.ts
+++ b/core/modules/DiscordBot/commands/status.ts
@@ -93,7 +93,11 @@ export const generateStatusMessage = (
     }
 
     //Prepare status placeholders
-    if (fxMonitorStatus.health === FxMonitorHealth.ONLINE) {
+    if (txConfig.whitelist.mode === 'adminOnly') {
+        placeholders.statusString = embedConfigJson?.maintenanceString ?? '🟠 Maintenance';
+        placeholders.statusColor = embedConfigJson?.maintenanceColor ?? "#FD8C4C";
+    }
+    else if (fxMonitorStatus.health === FxMonitorHealth.ONLINE) {
         placeholders.statusString = embedConfigJson?.onlineString ?? '🟢 Online';
         placeholders.statusColor = embedConfigJson?.onlineColor ?? "#0BA70B";
     } else if (fxMonitorStatus.health === FxMonitorHealth.PARTIAL) {

--- a/core/modules/DiscordBot/defaultJsons.ts
+++ b/core/modules/DiscordBot/defaultJsons.ts
@@ -37,6 +37,8 @@ export const defaultEmbedJson = JSON.stringify({
 });
 
 export const defaultEmbedConfigJson = JSON.stringify({
+    "maintenanceString": "🟠 Maintenance",
+    "maintenanceColor": "#FD8C4C",
     "onlineString": "🟢 Online",
     "onlineColor": "#0BA70B",
     "partialString": "🟡 Partial",


### PR DESCRIPTION
This PR aims to add a "Maintenance" status to the discord bot embed when the server is in admin-only mode.

![](https://r2.fivemanage.com/image/9Lc01hbgRMth.png)