### PR TITLE
fix(shared): enable ESM import

### DIFF
--- a/shared/package.json
+++ b/shared/package.json
@@ -11,6 +11,7 @@
     "keywords": [],
     "author": "André Tabarra",
     "license": "MIT",
+    "type": "module",
     "dependencies": {},
     "devDependencies": {}
 }


### PR DESCRIPTION
fix error when running `npm run dev` on core 
`SyntaxError: The requested module '../../shared/txDevEnv' does not provide an export named 'parseTxDevEnv'`

so just enable ESM import on shared package.json