### PR TITLE
refactor(menu): migrate permission checks to server-side callbacks

### DIFF
--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -24,6 +24,7 @@ shared_scripts {
 server_scripts {
     'entrypoint.js',
     'resource/sv_main.lua', --must run first
+    'resource/sv_callback.lua',
     'resource/sv_admins.lua',
     'resource/sv_logger.lua',
     'resource/sv_resources.lua',
@@ -43,6 +44,7 @@ server_scripts {
 
 client_scripts {
     'resource/cl_main.lua',
+    'resource/cl_callback.lua',
     'resource/cl_logger.lua',
     'resource/cl_playerlist.lua',
     'resource/menu/client/cl_webpipe.lua',

--- a/resource/cl_callback.lua
+++ b/resource/cl_callback.lua
@@ -5,13 +5,16 @@ function TriggerServerCallback(name, ...)
     local requestId = GetGameTimer() .. math.random(1, 999999)
     pendingCallbacks[requestId] = p
     TriggerServerEvent(eventReq, name, requestId, ...)
-    return Citizen.Await(p)
+    
+    local result = Citizen.Await(p)
+    
+    return table.unpack(result)
 end
 
 RegisterNetEvent(eventRes, function(requestId, ...)
     local p = pendingCallbacks[requestId]
     if p then
-        p:resolve(...)
+        p:resolve({ ... })
         pendingCallbacks[requestId] = nil
     end
 end)

--- a/resource/cl_callback.lua
+++ b/resource/cl_callback.lua
@@ -1,0 +1,17 @@
+local pendingCallbacks = {}
+
+function TriggerServerCallback(name, ...)
+    local p = promise.new()
+    local requestId = GetGameTimer() .. math.random(1, 999999)
+    pendingCallbacks[requestId] = p
+    TriggerServerEvent(eventReq, name, requestId, ...)
+    return Citizen.Await(p)
+end
+
+RegisterNetEvent(eventRes, function(requestId, ...)
+    local p = pendingCallbacks[requestId]
+    if p then
+        p:resolve(...)
+        pendingCallbacks[requestId] = nil
+    end
+end)

--- a/resource/menu/client/cl_base.lua
+++ b/resource/menu/client/cl_base.lua
@@ -90,11 +90,10 @@ end)
 if not TX_MENU_ENABLED then return end
 
 -- Checking with server if we are an admin
-TriggerServerEvent('txsv:checkIfAdmin')
-
--- Triggered as callback of txsv:checkIfAdmin
-RegisterNetEvent('txcl:setAdmin', function(username, perms, rejectReason)
-  if type(perms) == 'table' then
+function checkIfAdmin() 
+  local username, perms, rejectReason = TriggerServerCallback('txsv:cb:checkPerms')
+  print(username, perms, rejectReason)
+  if username and perms and type(perms) == "table" then
     debugPrint("^2[AUTH] logged in as '" .. username .. "' with perms: " .. json.encode(perms or "nil"))
     menuIsAccessible = true
     menuPermissions = perms
@@ -125,8 +124,11 @@ RegisterNetEvent('txcl:setAdmin', function(username, perms, rejectReason)
     menuPermissions = {}
   end
   sendMenuMessage('setPermissions', menuPermissions)
-end)
+end
 
+CreateThread(function()
+  checkIfAdmin()
+end)
 
 --[[ Debug Events / Commands ]]
 -- Command/event to trigger a authentication attempt
@@ -135,7 +137,7 @@ local function retryAuthentication()
   menuIsAccessible = false
   menuPermissions = {}
   sendMenuMessage('setPermissions', menuPermissions)
-  TriggerServerEvent('txsv:checkIfAdmin')
+  checkIfAdmin()
 end
 RegisterNetEvent('txcl:reAuth', retryAuthentication)
 RegisterCommand('txAdmin-reauth', function()

--- a/resource/menu/client/cl_functions.lua
+++ b/resource/menu/client/cl_functions.lua
@@ -126,18 +126,14 @@ end
 ---@param perms table Array of all player permissions
 ---@param perm string The specific permission
 ---@return boolean
-function DoesPlayerHavePerm(perms, perm)
-    if type(perms) ~= 'table' then
+function DoesPlayerHavePerm(perm)
+    local hasPerm = TriggerServerCallback('txsv:cb:checkPermission', perm)
+
+    if hasPerm then
+        return true
+    else
         return false
     end
-
-    for _, v in pairs(perms) do
-        if v == perm or v == 'all_permissions' then
-            return true
-        end
-    end
-
-    return false
 end
 
 -- Sound libraries

--- a/resource/menu/client/cl_main_page.lua
+++ b/resource/menu/client/cl_main_page.lua
@@ -16,7 +16,7 @@ RegisterSecureNuiCallback('tpToCoords', function(data, cb)
 end)
 RegisterCommand('txAdmin:menu:tpToCoords', function()
     if not menuIsAccessible then return end
-    if not DoesPlayerHavePerm(menuPermissions, 'players.teleport') then
+    if not DoesPlayerHavePerm('players.teleport') then
         return sendSnackbarMessage('error', 'nui_menu.misc.no_perms', true)
     end
     toggleMenuVisibility(true)
@@ -32,7 +32,7 @@ end
 RegisterSecureNuiCallback('tpToWaypoint', reqTpToWaypoint)
 RegisterCommand('txAdmin:menu:tpToWaypoint', function()
     if not menuIsAccessible then return end
-    if not DoesPlayerHavePerm(menuPermissions, 'players.teleport') then
+    if not DoesPlayerHavePerm('players.teleport') then
         return sendSnackbarMessage('error', 'nui_menu.misc.no_perms', true)
     end
     reqTpToWaypoint()
@@ -50,7 +50,7 @@ end
 RegisterSecureNuiCallback('tpBack', reqTpBack)
 RegisterCommand('txAdmin:menu:tpBack', function()
     if not menuIsAccessible then return end
-    if not DoesPlayerHavePerm(menuPermissions, 'players.teleport') then
+    if not DoesPlayerHavePerm('players.teleport') then
         return sendSnackbarMessage('error', 'nui_menu.misc.no_perms', true)
     end
     reqTpBack()
@@ -82,7 +82,7 @@ RegisterSecureNuiCallback('clearArea', function(radius, cb)
 end)
 RegisterCommand('txAdmin:menu:clearArea', function()
     if not menuIsAccessible then return end
-    if not DoesPlayerHavePerm(menuPermissions, 'menu.clear_area') then
+    if not DoesPlayerHavePerm('menu.clear_area') then
         return sendSnackbarMessage('error', 'nui_menu.misc.no_perms', true)
     end
     toggleMenuVisibility(true)
@@ -117,7 +117,7 @@ end
 RegisterSecureNuiCallback('healMyself', reqHealMyself)
 RegisterCommand('txAdmin:menu:healMyself', function()
     if not menuIsAccessible then return end
-    if not DoesPlayerHavePerm(menuPermissions, 'players.heal') then
+    if not DoesPlayerHavePerm('players.heal') then
         return sendSnackbarMessage('error', 'nui_menu.misc.no_perms', true)
     end
     reqHealMyself()
@@ -275,6 +275,10 @@ end)
 
 -- Teleport to the current waypoint
 RegisterNetEvent('txcl:tpToWaypoint', function()
+    if not DoesPlayerHavePerm('players.teleport') then
+        return sendSnackbarMessage('error', 'nui_menu.misc.no_perms', true)
+    end
+    
     if not IsWaypointActive() then
         return sendSnackbarMessage('error', 'nui_menu.page_main.teleport.waypoint.error', true)
     end

--- a/resource/menu/client/cl_player_ids.lua
+++ b/resource/menu/client/cl_player_ids.lua
@@ -202,7 +202,7 @@ end)
 
 RegisterCommand('txAdmin:menu:togglePlayerIDs', function()
     if not menuIsAccessible then return end
-    if not DoesPlayerHavePerm(menuPermissions, 'menu.viewids') then
+    if not DoesPlayerHavePerm('menu.viewids') then
         return sendSnackbarMessage('error', 'nui_menu.misc.no_perms', true)
     end
     togglePlayerIDsHandler()

--- a/resource/menu/client/cl_player_mode.lua
+++ b/resource/menu/client/cl_player_mode.lua
@@ -243,7 +243,7 @@ end
 -- NoClip toggle keybind
 RegisterCommand('txAdmin:menu:noClipToggle', function()
     if not menuIsAccessible then return end
-    if not DoesPlayerHavePerm(menuPermissions, 'players.playermode') then
+    if not DoesPlayerHavePerm('players.playermode') then
         return sendSnackbarMessage('error', 'nui_menu.misc.no_perms', true)
     end
     askChangePlayerMode(noClipEnabled and 'none' or 'noclip')
@@ -257,6 +257,10 @@ end)
 
 -- [[ Player mode changed cb event ]]
 RegisterNetEvent('txcl:setPlayerMode', function(mode, ptfx)
+    if not DoesPlayerHavePerm('players.playermode') then
+        return sendSnackbarMessage('error', 'nui_menu.misc.no_perms', true)
+    end
+
     if ptfx then
         CreatePlayerModePtfxLoop(PlayerPedId(), true)
     end

--- a/resource/menu/client/cl_spectate.lua
+++ b/resource/menu/client/cl_spectate.lua
@@ -264,6 +264,10 @@ end)
 
 -- Client-side event handler for an authorized spectate request
 RegisterNetEvent('txcl:spectate:start', function(targetServerId, targetCoords)
+    if not DoesPlayerHavePerm('players.spectate') then
+        return sendSnackbarMessage('error', 'nui_menu.misc.no_perms', true)
+    end
+    
     if IS_REDM then
         redmPromptTitle = CreateVarString(10, 'LITERAL_STRING', 'Spectate')
         redmInstructionGroup = makeRedmInstructionalGroup(keysTable)

--- a/resource/menu/client/cl_vehicle.lua
+++ b/resource/menu/client/cl_vehicle.lua
@@ -138,7 +138,7 @@ RegisterSecureNuiCallback('spawnVehicle', function(data, cb)
 end)
 RegisterCommand('txAdmin:menu:spawnVehicle', function()
     if not menuIsAccessible then return end
-    if not DoesPlayerHavePerm(menuPermissions, 'menu.vehicle') then
+    if not DoesPlayerHavePerm('menu.vehicle') then
         return sendSnackbarMessage('error', 'nui_menu.misc.no_perms', true)
     end
     toggleMenuVisibility(true)
@@ -159,7 +159,7 @@ end
 RegisterSecureNuiCallback('deleteVehicle', reqVehicleDelete)
 RegisterCommand('txAdmin:menu:deleteVehicle', function()
     if not menuIsAccessible then return end
-    if not DoesPlayerHavePerm(menuPermissions, 'menu.vehicle') then
+    if not DoesPlayerHavePerm('menu.vehicle') then
         return sendSnackbarMessage('error', 'nui_menu.misc.no_perms', true)
     end
     reqVehicleDelete()
@@ -177,7 +177,7 @@ end
 RegisterSecureNuiCallback('fixVehicle', reqVehicleFix)
 RegisterCommand('txAdmin:menu:fixVehicle', function()
     if not menuIsAccessible then return end
-    if not DoesPlayerHavePerm(menuPermissions, 'menu.vehicle') then
+    if not DoesPlayerHavePerm('menu.vehicle') then
         return sendSnackbarMessage('error', 'nui_menu.misc.no_perms', true)
     end
     reqVehicleFix()
@@ -195,7 +195,7 @@ end
 RegisterSecureNuiCallback('boostVehicle', reqVehicleBoost)
 RegisterCommand('txAdmin:menu:boostVehicle', function()
     if not menuIsAccessible then return end
-    if not DoesPlayerHavePerm(menuPermissions, 'menu.vehicle') then
+    if not DoesPlayerHavePerm('menu.vehicle') then
         return sendSnackbarMessage('error', 'nui_menu.misc.no_perms', true)
     end
     reqVehicleBoost()

--- a/resource/menu/server/sv_functions.lua
+++ b/resource/menu/server/sv_functions.lua
@@ -22,3 +22,7 @@ function PlayerHasTxPermission(source, reqPerm)
       source, reqPerm, (allow and '^2true' or '^1false')))
   return allow
 end
+
+RegisterServerCallback('txsv:cb:checkPermission', function(source, reqPerm)
+  return PlayerHasTxPermission(source, reqPerm)
+end)

--- a/resource/shared.lua
+++ b/resource/shared.lua
@@ -104,3 +104,9 @@ end
 function GetPedHealthPercent(ped)
   return math.floor((GetEntityHealth(ped) / GetEntityMaxHealth(ped)) * 100)
 end
+
+
+
+--- Shared callback event names
+eventReq = 'tx:internal:cb:req'
+eventRes = 'tx:internal:cb:res'

--- a/resource/sv_callback.lua
+++ b/resource/sv_callback.lua
@@ -1,0 +1,14 @@
+local registeredCallbacks = {}
+
+function RegisterServerCallback(name, cb)
+    registeredCallbacks[name] = cb
+end
+
+RegisterNetEvent(eventReq, function(name, requestId, ...)
+    local src = source
+    local cb = registeredCallbacks[name]
+    if cb then
+        local result = cb(src, ...)
+        TriggerClientEvent(eventRes, src, requestId, result)
+    end
+end)

--- a/resource/sv_callback.lua
+++ b/resource/sv_callback.lua
@@ -8,7 +8,8 @@ RegisterNetEvent(eventReq, function(name, requestId, ...)
     local src = source
     local cb = registeredCallbacks[name]
     if cb then
-        local result = cb(src, ...)
-        TriggerClientEvent(eventRes, src, requestId, result)
+        local result = { cb(src, ...) }
+        
+        TriggerClientEvent(eventRes, src, requestId, table.unpack(result))
     end
 end)


### PR DESCRIPTION
Implemented a lightweight callback system to enforce server-side permission validation.

Previously, permission checks were relying on client-side data, which made the system vulnerable to exploitation via Lua injectors.

Changes:
- Added `sv_callback.lua` and `cl_callback.lua` for handling server-client requests.
- Refactored `cl_functions.lua` and menu logic to validate permissions via server callback before execution.
- Ensured all menu actions are now strictly verified by the server.