### PR TITLE
Fix build error

### DIFF
--- a/shared/package.json
+++ b/shared/package.json
@@ -1,6 +1,7 @@
 {
     "name": "txadmin-shared",
     "version": "1.0.0",
+    "type": "module",
     "description": "The shared package contains stuff used in more than one package, no build step required.",
     "main": "index.js",
     "scripts": {


### PR DESCRIPTION
When building the core we had this error
```
import { parseTxDevEnv } from '../../shared/txDevEnv';
         ^

SyntaxError: The requested module '../../shared/txDevEnv' does not provide an export named 'parseTxDevEnv'
```

All credits goes to @yorick2002 for this fix