### PR TITLE
Fix FxScheduler cron job

### DIFF
--- a/core/modules/FxScheduler.ts
+++ b/core/modules/FxScheduler.ts
@@ -65,7 +65,6 @@ export default class FxScheduler {
         setInterval(() => {
             const currentMinute = Math.floor(Date.now() / 60000);
             if (currentMinute > this.lastMinute) {
-                this.lastMinute = currentMinute;
                 this.checkSchedule();
                 txCore.webServer.webSocket.pushRefresh('status');
             }
@@ -237,6 +236,7 @@ export default class FxScheduler {
      * Checks the schedule to see if it's time to announce or restart the server
      */
     async checkSchedule(calculateOnly = false) {
+        this.lastMinute = Math.floor(Date.now() / 60000);
         //Check settings and temp scheduled restart
         let nextRestart: RestartInfo;
         if (this.nextTempSchedule) {

--- a/core/modules/FxScheduler.ts
+++ b/core/modules/FxScheduler.ts
@@ -53,6 +53,7 @@ export default class FxScheduler {
     private nextTempSchedule: RestartInfo | false = false;
     private calculatedNextRestartMinuteFloorTs: number | false = false;
     private nextSkip: number | false = false;
+    private lastMinute = Math.floor(Date.now() / 60000);
 
     constructor() {
         //Initial check to update status
@@ -62,9 +63,13 @@ export default class FxScheduler {
 
         //Cron Function 
         setInterval(() => {
-            this.checkSchedule();
-            txCore.webServer.webSocket.pushRefresh('status');
-        }, 60 * 1000);
+            const currentMinute = Math.floor(Date.now() / 60000);
+            if (currentMinute > this.lastMinute) {
+                this.lastMinute = currentMinute;
+                this.checkSchedule();
+                txCore.webServer.webSocket.pushRefresh('status');
+            }
+        }, 1000);
     }
 
 


### PR DESCRIPTION
Sometimes, the checkSchedule was triggered twice in the same minute (probably one by the "cron" and one by another function)
This caused the txAdmin:events:scheduledRestart event to be sent twice and ultimately (for us) the "reboot in x minutes" announcement message in our discord guild was sent 2 times