### PR TITLE
fix(noclip): Delete UI prompts after noclipping

### DIFF
--- a/resource/menu/vendor/freecam/main.lua
+++ b/resource/menu/vendor/freecam/main.lua
@@ -141,6 +141,10 @@ function StartFreecamThread()
     --cleanup of the scaleform movie
     if IS_FIVEM then
       SetScaleformMovieAsNoLongerNeeded()
+    else
+      for _, prompt in pairs(redmInstructionGroup.prompts) do
+        UiPromptDelete(prompt)
+      end
     end
   end)
 end


### PR DESCRIPTION
A user in the txAdmin Discord reported a memory leak visible in the CGameScriptResource pool in RedM due to txAdmin not cleaning up the UI prompts after noclipping.

This PR makes sure txAdmin deletes the UI prompts after noclipping

Original report: https://discord.com/channels/577993482761928734/1461450141612376105