### PR TITLE
feat(terminal) Allow interactive terminal via convar.

### DIFF
--- a/core/modules/FxRunner/index.ts
+++ b/core/modules/FxRunner/index.ts
@@ -203,7 +203,8 @@ export default class FxRunner {
             fxSpawnVars.args,
             {
                 cwd: fxSpawnVars.dataPath,
-                stdio: ['pipe', 'pipe', 'pipe', 'pipe'],
+                // Check whether to allow user input in the terminal
+                stdio: GetConvar("txAdmin-interactive", "false") === "true" ? "inherit" : ['pipe', 'pipe', 'pipe', 'pipe'],
             },
         );
         if (!isValidChildProcess(childProc)) {


### PR DESCRIPTION
A very simple change that allows users to set a convar `txAdmin-interactive` to recover direct server terminal input.

Usage example:
`./FXServer.exe  +set txAdmin-interactive true`
