### PR TITLE
fix(panel): broken bot setup documentation links

### DIFF
--- a/panel/src/pages/Settings/tabCards/discord.tsx
+++ b/panel/src/pages/Settings/tabCards/discord.tsx
@@ -125,7 +125,7 @@ export default function ConfigCardDiscord({ cardCtx, pageCtx }: SettingsCardProp
                 />
                 <SettingItemDesc>
                     To get a token and the bot to join your server, follow these two guides: <br />
-                    <TxAnchor  href="https://discordjs.guide/preparations/setting-up-a-bot-application.html">Setting up a bot application</TxAnchor> and <TxAnchor href="https://discordjs.guide/preparations/adding-your-bot-to-servers.html">Adding your bot to servers</TxAnchor> <br />
+                    <TxAnchor href="https://discordjs.guide/legacy/preparations/app-setup">Setting up a bot application</TxAnchor> and <TxAnchor href="https://discordjs.guide/legacy/preparations/adding-your-app">Adding your bot to servers</TxAnchor> <br />
                     <strong>Note:</strong> Do not reuse the same token for another bot. <br />
                     <strong>Note:</strong> The bot requires the <strong>Server Members</strong> intent, which can be set at the <TxAnchor href="https://discord.com/developers/applications">Discord Developer Portal</TxAnchor>.
                 </SettingItemDesc>


### PR DESCRIPTION
- previous links pointed to pages that no longer exist with the recent DJS docs changes


> Realized my original PR was targeting the wrong branch.