### PR TITLE
fix(resource): txPrint does not reset color formatting

### DIFF
--- a/resource/shared.lua
+++ b/resource/shared.lua
@@ -66,12 +66,12 @@ end
 
 --- Prints formatted string to console
 function txPrint(...)
-  local msg = ('^5[txAdmin]^0%s^0'):format(_formatTxString({...}))
+  local msg = ('^5[txAdmin]^0%s^7'):format(_formatTxString({...}))
   print(msg)
 end
 
 function txPrintError(...)
-  local msg = ('^5[txAdmin]^1%s^0'):format(_formatTxString({...}))
+  local msg = ('^5[txAdmin]^1%s^7'):format(_formatTxString({...}))
   print(msg)
 end
 


### PR DESCRIPTION
`txPrint` function ends its console output with `^0`, which is not a native color used in the FXServer console, so it ends up coloring next outputs. Instead, in this fix, txPrint ends with `^7`, which resets the color to native.