### PR TITLE
Feat: discord punishment logs

### DIFF
--- a/core/modules/ConfigStore/schema/discordBot.ts
+++ b/core/modules/ConfigStore/schema/discordBot.ts
@@ -26,14 +26,14 @@ const guild = typeNullableConfig({
 });
 
 const punishmentsChannel = typeNullableConfig({
-    name: 'Restarts Channel ID',
+    name: 'Punishments Channel ID',
     default: null,
     validator: discordSnowflakeSchema.nullable(),
     fixer: SYM_FIXER_DEFAULT,
 });
 
-const restartsChannel = typeNullableConfig({
-    name: 'Warnings Channel ID',
+const announcementsChannel = typeNullableConfig({
+    name: 'Announcements Channel ID',
     default: null,
     validator: discordSnowflakeSchema.nullable(),
     fixer: SYM_FIXER_DEFAULT,
@@ -71,7 +71,7 @@ export default {
     token,
     guild,
     punishmentsChannel,
-    restartsChannel,
+    announcementsChannel,
     embedJson,
     embedConfigJson,
 } as const;

--- a/core/modules/ConfigStore/schema/discordBot.ts
+++ b/core/modules/ConfigStore/schema/discordBot.ts
@@ -25,7 +25,14 @@ const guild = typeNullableConfig({
     fixer: SYM_FIXER_DEFAULT,
 });
 
-const warningsChannel = typeNullableConfig({
+const punishmentsChannel = typeNullableConfig({
+    name: 'Restarts Channel ID',
+    default: null,
+    validator: discordSnowflakeSchema.nullable(),
+    fixer: SYM_FIXER_DEFAULT,
+});
+
+const restartsChannel = typeNullableConfig({
     name: 'Warnings Channel ID',
     default: null,
     validator: discordSnowflakeSchema.nullable(),
@@ -63,7 +70,8 @@ export default {
     enabled,
     token,
     guild,
-    warningsChannel,
+    punishmentsChannel,
+    restartsChannel,
     embedJson,
     embedConfigJson,
 } as const;

--- a/core/modules/ConfigStore/schema/oldConfig.ts
+++ b/core/modules/ConfigStore/schema/oldConfig.ts
@@ -35,7 +35,7 @@ const restructureOldConfig = (old: any) => {
             token: old?.discordBot?.token,
             guild: old?.discordBot?.guild,
             punishmentsChannel: old?.discordBot?.punishmentsChannel,
-            restartsChannel: old?.discordBot?.announceChannel, //NOTE:renamed
+            announcementsChannel: old?.discordBot?.announceChannel, //NOTE:renamed
             embedJson: old?.discordBot?.embedJson,
             embedConfigJson: old?.discordBot?.embedConfigJson,
         },

--- a/core/modules/ConfigStore/schema/oldConfig.ts
+++ b/core/modules/ConfigStore/schema/oldConfig.ts
@@ -34,7 +34,8 @@ const restructureOldConfig = (old: any) => {
             enabled: old?.discordBot?.enabled,
             token: old?.discordBot?.token,
             guild: old?.discordBot?.guild,
-            warningsChannel: old?.discordBot?.announceChannel, //NOTE:renamed
+            punishmentsChannel: old?.discordBot?.punishmentsChannel,
+            restartsChannel: old?.discordBot?.announceChannel, //NOTE:renamed
             embedJson: old?.discordBot?.embedJson,
             embedConfigJson: old?.discordBot?.embedConfigJson,
         },

--- a/core/modules/DiscordBot/index.ts
+++ b/core/modules/DiscordBot/index.ts
@@ -7,6 +7,7 @@ import consoleFactory from '@lib/console';
 import { embedColors } from './discordHelpers';
 import { DiscordBotStatus } from '@shared/enums';
 import { UpdateConfigKeySet } from '@modules/ConfigStore/utils';
+import { AuthedAdmin } from '@modules/WebServer/authLogic';
 const console = consoleFactory(modulename);
 
 
@@ -20,10 +21,16 @@ type AnnouncementType = {
     description: string | MessageTranslationType;
     type: keyof typeof embedColors;
 }
+type PunishmentType = {
+    admin: AuthedAdmin;
+    title?: string | MessageTranslationType;
+    description: string | MessageTranslationType;
+    type: keyof typeof embedColors;
+}
 
 type SpawnConfig = Pick<
     TxConfigs['discordBot'],
-    'enabled' | 'token' | 'guild' | 'warningsChannel'
+    'enabled' | 'token' | 'guild' | 'punishmentsChannel' | 'restartsChannel'
 >;
 
 
@@ -59,6 +66,7 @@ export default class DiscordBot {
     guild: Discord.Guild | undefined;
     guildName: string | undefined;
     announceChannel: Discord.TextBasedChannel | undefined;
+    punishmentsChannel: Discord.TextBasedChannel | undefined;
     #lastDisallowedIntentsError: number = 0; //ms
     #lastGuildMembersCacheRefresh: number = 0; //ms
     #lastStatus = DiscordBotStatus.Disabled;
@@ -161,7 +169,7 @@ export default class DiscordBot {
     async sendAnnouncement(content: AnnouncementType) {
         if (!txConfig.discordBot.enabled) return;
         if (
-            !txConfig.discordBot.warningsChannel
+            !txConfig.discordBot.punishmentsChannel
             || !this.#client?.isReady()
             || !this.announceChannel
         ) {
@@ -187,6 +195,47 @@ export default class DiscordBot {
             await this.announceChannel.send({ embeds: [embed] });
         } catch (error) {
             console.error(`Error sending Discord announcement: ${(error as Error).message}`);
+        }
+    }
+
+
+    /**
+     * Send an announcement to the configured channel
+     */
+    async sendPunishment(content: PunishmentType) {
+        if (!txConfig.discordBot.enabled) return;
+        if (
+            !txConfig.discordBot.punishmentsChannel
+            || !this.#client?.isReady()
+            || !this.punishmentsChannel
+        ) {
+            console.verbose.warn('not ready yet to send announcement');
+            return false;
+        }
+
+        try {
+            let title;
+            if (content.title) {
+                title = (typeof content.title === 'string')
+                    ? content.title
+                    : txCore.translator.t(content.title.key, content.title.data);
+            }
+            let description;
+            if (content.description) {
+                description = (typeof content.description === 'string')
+                    ? content.description
+                    : txCore.translator.t(content.description.key, content.description.data);
+            }
+
+            const embed = new EmbedBuilder({ title, description })
+                .setColor(embedColors[content.type])
+                .setAuthor({
+                    name: content.admin.name,
+                    iconURL: content.admin.profilePicture,
+                });
+            await this.punishmentsChannel.send({ embeds: [embed] });
+        } catch (error) {
+            console.error(`Error sending Discord punishment: ${(error as Error).message}`);
         }
     }
 
@@ -239,7 +288,8 @@ export default class DiscordBot {
             enabled: txConfig.discordBot.enabled,
             token: txConfig.discordBot.token,
             guild: txConfig.discordBot.guild,
-            warningsChannel: txConfig.discordBot.warningsChannel,
+            punishmentsChannel: txConfig.discordBot.punishmentsChannel,
+            restartsChannel: txConfig.discordBot.restartsChannel,
         }
         if (!botCfg.enabled) return;
 
@@ -354,13 +404,25 @@ export default class DiscordBot {
                     }
                 }
 
-                //Fetching announcements channel
-                if (botCfg.warningsChannel) {
-                    const fetchedChannel = this.#client.channels.cache.find((x) => x.id === botCfg.warningsChannel);
+                //Fetching warnings channel
+                if (botCfg.punishmentsChannel) {
+                    const fetchedChannel = this.#client.channels.cache.find((x) => x.id === botCfg.punishmentsChannel);
                     if (!fetchedChannel) {
-                        return sendError(`Channel ${botCfg.warningsChannel} not found.`);
+                        return sendError(`Channel ${botCfg.punishmentsChannel} not found.`);
                     } else if (fetchedChannel.type !== ChannelType.GuildText && fetchedChannel.type !== ChannelType.GuildAnnouncement) {
-                        return sendError(`Channel ${botCfg.warningsChannel} - ${(fetchedChannel as any)?.name} is not a text or announcement channel.`);
+                        return sendError(`Channel ${botCfg.punishmentsChannel} - ${(fetchedChannel as any)?.name} is not a text or announcement channel.`);
+                    } else {
+                        this.punishmentsChannel = fetchedChannel;
+                    }
+                }
+
+                //Fetching announcements channel
+                if (botCfg.restartsChannel) {
+                    const fetchedChannel = this.#client.channels.cache.find((x) => x.id === botCfg.restartsChannel);
+                    if (!fetchedChannel) {
+                        return sendError(`Channel ${botCfg.restartsChannel} not found.`);
+                    } else if (fetchedChannel.type !== ChannelType.GuildText && fetchedChannel.type !== ChannelType.GuildAnnouncement) {
+                        return sendError(`Channel ${botCfg.restartsChannel} - ${(fetchedChannel as any)?.name} is not a text or announcement channel.`);
                     } else {
                         this.announceChannel = fetchedChannel;
                     }

--- a/core/modules/DiscordBot/index.ts
+++ b/core/modules/DiscordBot/index.ts
@@ -30,7 +30,7 @@ type PunishmentType = {
 
 type SpawnConfig = Pick<
     TxConfigs['discordBot'],
-    'enabled' | 'token' | 'guild' | 'punishmentsChannel' | 'restartsChannel'
+    'enabled' | 'token' | 'guild' | 'punishmentsChannel' | 'announcementsChannel'
 >;
 
 
@@ -289,7 +289,7 @@ export default class DiscordBot {
             token: txConfig.discordBot.token,
             guild: txConfig.discordBot.guild,
             punishmentsChannel: txConfig.discordBot.punishmentsChannel,
-            restartsChannel: txConfig.discordBot.restartsChannel,
+            announcementsChannel: txConfig.discordBot.announcementsChannel,
         }
         if (!botCfg.enabled) return;
 
@@ -417,12 +417,12 @@ export default class DiscordBot {
                 }
 
                 //Fetching announcements channel
-                if (botCfg.restartsChannel) {
-                    const fetchedChannel = this.#client.channels.cache.find((x) => x.id === botCfg.restartsChannel);
+                if (botCfg.announcementsChannel) {
+                    const fetchedChannel = this.#client.channels.cache.find((x) => x.id === botCfg.announcementsChannel);
                     if (!fetchedChannel) {
-                        return sendError(`Channel ${botCfg.restartsChannel} not found.`);
+                        return sendError(`Channel ${botCfg.announcementsChannel} not found.`);
                     } else if (fetchedChannel.type !== ChannelType.GuildText && fetchedChannel.type !== ChannelType.GuildAnnouncement) {
-                        return sendError(`Channel ${botCfg.restartsChannel} - ${(fetchedChannel as any)?.name} is not a text or announcement channel.`);
+                        return sendError(`Channel ${botCfg.announcementsChannel} - ${(fetchedChannel as any)?.name} is not a text or announcement channel.`);
                     } else {
                         this.announceChannel = fetchedChannel;
                     }

--- a/core/routes/history/actions.ts
+++ b/core/routes/history/actions.ts
@@ -99,6 +99,22 @@ async function handleBandIds(ctx: AuthedCtx): Promise<GenericApiOkResp> {
             expiration,
             false
         );
+
+        txCore.discordBot.sendPunishment({
+            admin: ctx.admin,
+            type: 'danger',
+            title: {
+                key: 'ban_messages.embed.title',
+            },
+            description: {
+                key: 'ban_messages.embed.idban_description',
+                data: {
+                    expiration: expiration ? `<t:${expiration}>` : 'X',
+                    reason,
+                    identifiers: identifiers.join('\n'),
+                }
+            }
+        });
     } catch (error) {
         return { error: `Failed to ban identifiers: ${(error as Error).message}` };
     }
@@ -162,6 +178,26 @@ async function handleRevokeAction(ctx: AuthedCtx): Promise<GenericApiOkResp> {
     try {
         action = txCore.database.actions.revoke(actionId, ctx.admin.name, perms) as DatabaseActionType;
         ctx.admin.logAction(`Revoked ${action.type} id ${actionId} from ${action.playerName ?? 'identifiers'}`);
+        
+        txCore.discordBot.sendPunishment({
+            admin: ctx.admin,
+            type: 'info',
+            title: {
+                key: 'revocation_messages.embed.title',
+                data: {
+                    action: action.type,
+                },
+            },
+            description: {
+                key: 'revocation_messages.embed.description',
+                data: {
+                    actionId,
+                    action: action.type,
+                    target: action.playerName ?? 'identifiers',
+                    identifiers: action.ids.join('\n'),
+                },
+            },
+        });
     } catch (error) {
         return { error: `Failed to revoke action: ${(error as Error).message}` };
     }

--- a/core/routes/player/actions.ts
+++ b/core/routes/player/actions.ts
@@ -117,6 +117,22 @@ async function handleWarning(ctx: AuthedCtx, player: PlayerClass): Promise<Gener
             reason,
             player.displayName,
         );
+        
+        txCore.discordBot.sendPunishment({
+            admin: ctx.admin,
+            type: 'warning',
+            title: {
+                key: 'warning_messages.embed.title',
+            },
+            description: {
+                key: 'warning_messages.embed.description',
+                data: {
+                    player: player.displayName,
+                    reason,
+                    identifiers: `${player.allIdentifiers.join('\n')}`,
+                },
+            },
+        });
     } catch (error) {
         return { error: `Failed to warn player: ${(error as Error).message}` };
     }
@@ -189,6 +205,23 @@ async function handleBan(ctx: AuthedCtx, player: PlayerClass): Promise<GenericAp
             player.displayName,
             allHwids
         );
+        
+        txCore.discordBot.sendPunishment({
+            admin: ctx.admin,
+            type: 'danger',
+            title: {
+                key: 'ban_messages.embed.title',
+            },
+            description: {
+                key: 'ban_messages.embed.playerban_description',
+                data: {
+                    player: player.displayName,
+                    reason,
+                    expiration: expiration ? `<t:${expiration}>` : 'X',
+                    identifiers: player.allIdentifiers.join('\n'),
+                }
+            }
+        });
     } catch (error) {
         return { error: `Failed to ban player: ${(error as Error).message}` };
     }
@@ -359,6 +392,21 @@ async function handleDirectMessage(ctx: AuthedCtx, player: PlayerClass): Promise
 
     try {
         ctx.admin.logAction(`DM to "${player.displayName}": ${message}`);
+        
+        txCore.discordBot.sendPunishment({
+            admin: ctx.admin,
+            type: 'danger',
+            title: {
+                key: 'dm_messages.embed.title',
+            },
+            description: {
+                key: 'dm_messages.embed.description',
+                data: {
+                    player: player.displayName,
+                    message,
+                }
+            }
+        });
 
         // Dispatch `txAdmin:events:playerDirectMessage`
         txCore.fxRunner.sendEvent('playerDirectMessage', {
@@ -406,6 +454,22 @@ async function handleKick(ctx: AuthedCtx, player: PlayerClass): Promise<GenericA
             'kick_messages.player',
             { reason: kickReason }
         );
+        
+        txCore.discordBot.sendPunishment({
+            admin: ctx.admin,
+            type: 'danger',
+            title: {
+                key: 'kick_messages.embed.title',
+            },
+            description: {
+                key: 'kick_messages.embed.description',
+                data: {
+                    player: player.displayName,
+                    reason: kickReason,
+                    identifiers: player.allIdentifiers.join('\n'),
+                }
+            }
+        });
 
         // Dispatch `txAdmin:events:playerKicked`
         txCore.fxRunner.sendEvent('playerKicked', {

--- a/core/routes/settings/saveConfigs.ts
+++ b/core/routes/settings/saveConfigs.ts
@@ -332,7 +332,7 @@ const handleDiscordCard: CardHandler = async (inputConfig, sendTypedResp) => {
         [schemas.enabled, inputConfig.discordBot.enabled],
         [schemas.token, inputConfig.discordBot.token],
         [schemas.guild, inputConfig.discordBot.guild],
-        [schemas.restartsChannel, inputConfig.discordBot.restartsChannel],
+        [schemas.announcementsChannel, inputConfig.discordBot.announcementsChannel],
         [schemas.punishmentsChannel, inputConfig.discordBot.punishmentsChannel],
     ]);
     if (validationError) {

--- a/core/routes/settings/saveConfigs.ts
+++ b/core/routes/settings/saveConfigs.ts
@@ -332,7 +332,8 @@ const handleDiscordCard: CardHandler = async (inputConfig, sendTypedResp) => {
         [schemas.enabled, inputConfig.discordBot.enabled],
         [schemas.token, inputConfig.discordBot.token],
         [schemas.guild, inputConfig.discordBot.guild],
-        [schemas.warningsChannel, inputConfig.discordBot.warningsChannel],
+        [schemas.restartsChannel, inputConfig.discordBot.restartsChannel],
+        [schemas.punishmentsChannel, inputConfig.discordBot.punishmentsChannel],
     ]);
     if (validationError) {
         return sendTypedResp({
@@ -360,7 +361,7 @@ const handleDiscordCard: CardHandler = async (inputConfig, sendTypedResp) => {
             //They have been validated, so this is fine
             token: inputConfig.discordBot.token as any,
             guild: inputConfig.discordBot.guild as any,
-            warningsChannel: inputConfig.discordBot.warningsChannel as any,
+            punishmentsChannel: inputConfig.discordBot.punishmentsChannel as any,
         });
     } catch (error) {
         const errorCode = (error as any).code;

--- a/locale/ar.json
+++ b/locale/ar.json
@@ -14,7 +14,11 @@
     "kick_messages": {
         "everyone": "تم طرد جميع اللاعبين: %{reason}.",
         "player": "تم طردك: %{reason}.",
-        "unknown_reason": "لسبب مجهول"
+        "unknown_reason": "لسبب مجهول",
+        "embed": {
+            "title": "Player Kicked",
+            "playerban_description": "**Player:** %{player}\n**Reason:** %{reason}\n\n**Identifiers:**\n```%{identifiers}```"
+        }
     },
     "ban_messages": {
         "kick_temporary": ".%{expiration} :ستنتهي صلاحية حظرك في .\"%{reason}\"  لقد تم حظرك من هذا الخادم لسبب (%{author})",
@@ -29,6 +33,11 @@
             "label_id": "معرف الحظر",
             "note_multiple_bans": ".ملاحظة: لديك أكثر من حظر نشط على المعرفات الخاصة بك",
             "note_diff_license": ".تتطابق مع تلك المرتبطة بهذا الحظر HWID مما يعني أن بعض معرفاتك <code>license</code> ملاحظة: تم تطبيق الحظر أعلاه على شخص آخر"
+        },
+        "embed": {
+            "title": "Player Banned",
+            "idban_description": "**Reason:** %{reason}\n**Expires:** %{expiration}\n\n**Identifiers:**\n```%{identifiers}```",
+            "playerban_description": "**Player:** %{player}\n**Reason:** %{reason}\n**Expires:** %{expiration}\n\n**Identifiers:**\n```%{identifiers}```"
         }
     },
     "whitelist_messages": {
@@ -362,6 +371,24 @@
                 "previous_ids": "المعرفات المستخدمة سابقًا",
                 "all_hwids": "كافة معرفات الأجهزة"
             }
+        }
+    },
+    "warning_messages": {
+        "embed": {
+            "title": "Player Warned",
+            "description": "**Player:** %{player}\n**Reason:** %{reason}\n\n**Identifiers:**\n```%{identifiers}```"
+        }
+    },
+    "revocation_messages": {
+        "embed": {
+            "title": "Action Revoked",
+            "description": "**Action Type:** %{action} (`#%{actionId}`)\n**Target:** %{target}\n\n**Identifiers:**\n```%{identifiers}```"
+        }
+    },
+    "dm_messages": {
+        "embed": {
+            "title": "Admin DM Sent",
+            "description": "**Recipient:** %{player}\n**Message:**\n%{message}"
         }
     }
 }

--- a/locale/bg.json
+++ b/locale/bg.json
@@ -14,7 +14,11 @@
     "kick_messages": {
         "everyone": "Всички играчи бяха изритани: %{reason}.",
         "player": "Вие бяхте изритан: %{reason}.",
-        "unknown_reason": "по неизвестна причина"
+        "unknown_reason": "по неизвестна причина",
+        "embed": {
+            "title": "Player Kicked",
+            "playerban_description": "**Player:** %{player}\n**Reason:** %{reason}\n\n**Identifiers:**\n```%{identifiers}```"
+        }
     },
     "ban_messages": {
         "kick_temporary": "(%{author}) Вие бяхте баннат: \"%{reason}\". Твоята забрана ще изтече след: %{expiration}.",
@@ -29,6 +33,11 @@
             "label_id": "Бан ID",
             "note_multiple_bans": "Забележка: Имате повече от един активен бан на вашите идентификатори.",
             "note_diff_license": "Забележка: Горния бан е приложен за друг <code>license</code>, което означава че някои от твоите ID-та/HWID-та съответстват на тези, свързани с този бан."
+        },
+        "embed": {
+            "title": "Player Banned",
+            "idban_description": "**Reason:** %{reason}\n**Expires:** %{expiration}\n\n**Identifiers:**\n```%{identifiers}```",
+            "playerban_description": "**Player:** %{player}\n**Reason:** %{reason}\n**Expires:** %{expiration}\n\n**Identifiers:**\n```%{identifiers}```"
         }
     },
     "whitelist_messages": {
@@ -362,6 +371,24 @@
                 "previous_ids": "Използвани преди това идентификатори",
                 "all_hwids": "Всички хардуерни ID-та"
             }
+        }
+    },
+    "warning_messages": {
+        "embed": {
+            "title": "Player Warned",
+            "description": "**Player:** %{player}\n**Reason:** %{reason}\n\n**Identifiers:**\n```%{identifiers}```"
+        }
+    },
+    "revocation_messages": {
+        "embed": {
+            "title": "Action Revoked",
+            "description": "**Action Type:** %{action} (`#%{actionId}`)\n**Target:** %{target}\n\n**Identifiers:**\n```%{identifiers}```"
+        }
+    },
+    "dm_messages": {
+        "embed": {
+            "title": "Admin DM Sent",
+            "description": "**Recipient:** %{player}\n**Message:**\n%{message}"
         }
     }
 }

--- a/locale/bs.json
+++ b/locale/bs.json
@@ -14,7 +14,11 @@
     "kick_messages": {
         "everyone": "All players kicked: %{reason}.",
         "player": "You have been kicked: %{reason}.",
-        "unknown_reason": "for unknown reason"
+        "unknown_reason": "for unknown reason",
+        "embed": {
+            "title": "Player Kicked",
+            "playerban_description": "**Player:** %{player}\n**Reason:** %{reason}\n\n**Identifiers:**\n```%{identifiers}```"
+        }
     },
     "ban_messages": {
         "kick_temporary": "(%{author}) Zabranjen vam je pristup ovom serveru zbog \"%{reason}\". Vaša zabrana istječe za: %{expiration}.",
@@ -29,6 +33,11 @@
             "label_id": "Ban ID",
             "note_multiple_bans": "Note: you have more than one active ban on your identifiers.",
             "note_diff_license": "Note: the ban above was applied for another <code>license</code>, which means some of your IDs/HWIDs match the ones associated with that ban."
+        },
+        "embed": {
+            "title": "Player Banned",
+            "idban_description": "**Reason:** %{reason}\n**Expires:** %{expiration}\n\n**Identifiers:**\n```%{identifiers}```",
+            "playerban_description": "**Player:** %{player}\n**Reason:** %{reason}\n**Expires:** %{expiration}\n\n**Identifiers:**\n```%{identifiers}```"
         }
     },
     "whitelist_messages": {
@@ -362,6 +371,24 @@
                 "previous_ids": "Previously Used Identifiers",
                 "all_hwids": "All Hardware IDs"
             }
+        }
+    },
+    "warning_messages": {
+        "embed": {
+            "title": "Player Warned",
+            "description": "**Player:** %{player}\n**Reason:** %{reason}\n\n**Identifiers:**\n```%{identifiers}```"
+        }
+    },
+    "revocation_messages": {
+        "embed": {
+            "title": "Action Revoked",
+            "description": "**Action Type:** %{action} (`#%{actionId}`)\n**Target:** %{target}\n\n**Identifiers:**\n```%{identifiers}```"
+        }
+    },
+    "dm_messages": {
+        "embed": {
+            "title": "Admin DM Sent",
+            "description": "**Recipient:** %{player}\n**Message:**\n%{message}"
         }
     }
 }

--- a/locale/cs.json
+++ b/locale/cs.json
@@ -14,7 +14,11 @@
     "kick_messages": {
         "everyone": "All players kicked: %{reason}.",
         "player": "You have been kicked: %{reason}.",
-        "unknown_reason": "for unknown reason"
+        "unknown_reason": "for unknown reason",
+        "embed": {
+            "title": "Player Kicked",
+            "playerban_description": "**Player:** %{player}\n**Reason:** %{reason}\n\n**Identifiers:**\n```%{identifiers}```"
+        }
     },
     "ban_messages": {
         "kick_temporary": "(%{author}) Byl jsi zabanován z důvodu: \"%{reason}\". Tvůj ban vyprší za: %{expiration}.",
@@ -29,6 +33,11 @@
             "label_id": "ID Banu",
             "note_multiple_bans": "Poznámka: Tvoje identifiery mají více aktivních banů.",
             "note_diff_license": "Poznámka: Tento ban byl udělen na herní <code>licenci</code>, což znamená že tvoje IDs/HWIDs se shodují s aktivním banem."
+        },
+        "embed": {
+            "title": "Player Banned",
+            "idban_description": "**Reason:** %{reason}\n**Expires:** %{expiration}\n\n**Identifiers:**\n```%{identifiers}```",
+            "playerban_description": "**Player:** %{player}\n**Reason:** %{reason}\n**Expires:** %{expiration}\n\n**Identifiers:**\n```%{identifiers}```"
         }
     },
     "whitelist_messages": {
@@ -362,6 +371,24 @@
                 "previous_ids": "Dříve použité identifiery",
                 "all_hwids": "Všechny ID hardwaru"
             }
+        }
+    },
+    "warning_messages": {
+        "embed": {
+            "title": "Player Warned",
+            "description": "**Player:** %{player}\n**Reason:** %{reason}\n\n**Identifiers:**\n```%{identifiers}```"
+        }
+    },
+    "revocation_messages": {
+        "embed": {
+            "title": "Action Revoked",
+            "description": "**Action Type:** %{action} (`#%{actionId}`)\n**Target:** %{target}\n\n**Identifiers:**\n```%{identifiers}```"
+        }
+    },
+    "dm_messages": {
+        "embed": {
+            "title": "Admin DM Sent",
+            "description": "**Recipient:** %{player}\n**Message:**\n%{message}"
         }
     }
 }

--- a/locale/da.json
+++ b/locale/da.json
@@ -14,7 +14,11 @@
     "kick_messages": {
         "everyone": "Alle spillere blev smidt ud: %{reason}.",
         "player": "Du er blevet smidt ud: %{reason}.",
-        "unknown_reason": "af ukendt årsag"
+        "unknown_reason": "af ukendt årsag",
+        "embed": {
+            "title": "Player Kicked",
+            "playerban_description": "**Player:** %{player}\n**Reason:** %{reason}\n\n**Identifiers:**\n```%{identifiers}```"
+        }
     },
     "ban_messages": {
         "kick_temporary": "(%{author}) Du er blevet bannet fra denne server på grund af \"%{reason}\". Dit ban udløber om: %{expiration}.",
@@ -29,6 +33,11 @@
             "label_id": "Ban ID",
             "note_multiple_bans": "Bemærk: Du har mere end én aktiv ban på dine identifikatorer.",
             "note_diff_license": "Bemærk: Bannet ovenfor blev påført en anden <code>licens</code>, hvilket betyder, at nogle af dine IDs/HWIDs matcher dem, der er forbundet med det ban."
+        },
+        "embed": {
+            "title": "Player Banned",
+            "idban_description": "**Reason:** %{reason}\n**Expires:** %{expiration}\n\n**Identifiers:**\n```%{identifiers}```",
+            "playerban_description": "**Player:** %{player}\n**Reason:** %{reason}\n**Expires:** %{expiration}\n\n**Identifiers:**\n```%{identifiers}```"
         }
     },
     "whitelist_messages": {
@@ -362,6 +371,24 @@
                 "helper_text": "Angiv varighed",
                 "submit": "Anvend ban"
             }
+        }
+    },
+    "warning_messages": {
+        "embed": {
+            "title": "Player Warned",
+            "description": "**Player:** %{player}\n**Reason:** %{reason}\n\n**Identifiers:**\n```%{identifiers}```"
+        }
+    },
+    "revocation_messages": {
+        "embed": {
+            "title": "Action Revoked",
+            "description": "**Action Type:** %{action} (`#%{actionId}`)\n**Target:** %{target}\n\n**Identifiers:**\n```%{identifiers}```"
+        }
+    },
+    "dm_messages": {
+        "embed": {
+            "title": "Admin DM Sent",
+            "description": "**Recipient:** %{player}\n**Message:**\n%{message}"
         }
     }
 }

--- a/locale/de.json
+++ b/locale/de.json
@@ -14,7 +14,11 @@
     "kick_messages": {
         "everyone": "Alle Spieler wurden gekickt: %{reason}.",
         "player": "Du wurdest gekickt: %{reason}.",
-        "unknown_reason": "aus unbekanntem Grund"
+        "unknown_reason": "aus unbekanntem Grund",
+        "embed": {
+            "title": "Player Kicked",
+            "playerban_description": "**Player:** %{player}\n**Reason:** %{reason}\n\n**Identifiers:**\n```%{identifiers}```"
+        }
     },
     "ban_messages": {
         "kick_temporary": "(%{author}) Du wurdest von diesem Server für %{expiration} gebannt. Grund: \"%{reason}\".",
@@ -29,6 +33,11 @@
             "label_id": "Bann-ID",
             "note_multiple_bans": "Info: Es gibt mehr als einen aktiven Bann für diesen Identifier",
             "note_diff_license": "Info: der oben angezeigte Ban wurde mit einer anderen <code>license</code> gespeichert. Das bedeutet, dass deine IDs/HWIDs passend sind wie zu diesem Ban."
+        },
+        "embed": {
+            "title": "Player Banned",
+            "idban_description": "**Reason:** %{reason}\n**Expires:** %{expiration}\n\n**Identifiers:**\n```%{identifiers}```",
+            "playerban_description": "**Player:** %{player}\n**Reason:** %{reason}\n**Expires:** %{expiration}\n\n**Identifiers:**\n```%{identifiers}```"
         }
     },
     "whitelist_messages": {
@@ -362,6 +371,24 @@
                 "previous_ids": "Zuvor benutzte Identifier",
                 "all_hwids": "Alle Hardware IDs"
             }
+        }
+    },
+    "warning_messages": {
+        "embed": {
+            "title": "Player Warned",
+            "description": "**Player:** %{player}\n**Reason:** %{reason}\n\n**Identifiers:**\n```%{identifiers}```"
+        }
+    },
+    "revocation_messages": {
+        "embed": {
+            "title": "Action Revoked",
+            "description": "**Action Type:** %{action} (`#%{actionId}`)\n**Target:** %{target}\n\n**Identifiers:**\n```%{identifiers}```"
+        }
+    },
+    "dm_messages": {
+        "embed": {
+            "title": "Admin DM Sent",
+            "description": "**Recipient:** %{player}\n**Message:**\n%{message}"
         }
     }
 }

--- a/locale/el.json
+++ b/locale/el.json
@@ -14,7 +14,11 @@
     "kick_messages": {
         "everyone": "All players kicked: %{reason}.",
         "player": "You have been kicked: %{reason}.",
-        "unknown_reason": "for unknown reason"
+        "unknown_reason": "for unknown reason",
+        "embed": {
+            "title": "Player Kicked",
+            "playerban_description": "**Player:** %{player}\n**Reason:** %{reason}\n\n**Identifiers:**\n```%{identifiers}```"
+        }
     },
     "ban_messages": {
         "kick_temporary": "(%{author}) Έχει απαγορευτεί η είσοδος σου στον διακομιστή για: \"%{reason}\". Η απαγορευσή σου θα λήξει σε: %{expiration}.",
@@ -29,6 +33,11 @@
             "label_id": "Ban ID",
             "note_multiple_bans": "Note: you have more than one active ban on your identifiers.",
             "note_diff_license": "Note: the ban above was applied for another <code>license</code>, which means some of your IDs/HWIDs match the ones associated with that ban."
+        },
+        "embed": {
+            "title": "Player Banned",
+            "idban_description": "**Reason:** %{reason}\n**Expires:** %{expiration}\n\n**Identifiers:**\n```%{identifiers}```",
+            "playerban_description": "**Player:** %{player}\n**Reason:** %{reason}\n**Expires:** %{expiration}\n\n**Identifiers:**\n```%{identifiers}```"
         }
     },
     "whitelist_messages": {
@@ -362,6 +371,24 @@
                 "previous_ids": "Previously Used Identifiers",
                 "all_hwids": "All Hardware IDs"
             }
+        }
+    },
+    "warning_messages": {
+        "embed": {
+            "title": "Player Warned",
+            "description": "**Player:** %{player}\n**Reason:** %{reason}\n\n**Identifiers:**\n```%{identifiers}```"
+        }
+    },
+    "revocation_messages": {
+        "embed": {
+            "title": "Action Revoked",
+            "description": "**Action Type:** %{action} (`#%{actionId}`)\n**Target:** %{target}\n\n**Identifiers:**\n```%{identifiers}```"
+        }
+    },
+    "dm_messages": {
+        "embed": {
+            "title": "Admin DM Sent",
+            "description": "**Recipient:** %{player}\n**Message:**\n%{message}"
         }
     }
 }

--- a/locale/en.json
+++ b/locale/en.json
@@ -11,10 +11,20 @@
         "schedule_warn": "This server is scheduled to restart in %{smart_count} minute. Please disconnect now. |||| This server is scheduled to restart in %{smart_count} minutes.",
         "schedule_warn_discord": "**%{servername}** is scheduled to restart in %{smart_count} minute. |||| **%{servername}** is scheduled to restart in %{smart_count} minutes."
     },
+    "warning_messages": {
+        "embed": {
+            "title": "Player Warned",
+            "description": "**Player:** %{player}\n**Reason:** %{reason}\n\n**Identifiers:**\n```%{identifiers}```"
+        }
+    },
     "kick_messages": {
         "everyone": "All players kicked: %{reason}.",
         "player": "You have been kicked: %{reason}.",
-        "unknown_reason": "for unknown reason"
+        "unknown_reason": "for unknown reason",
+        "embed": {
+            "title": "Player Kicked",
+            "playerban_description": "**Player:** %{player}\n**Reason:** %{reason}\n\n**Identifiers:**\n```%{identifiers}```"
+        }
     },
     "ban_messages": {
         "kick_temporary": "(%{author}) You have been banned from this server for \"%{reason}\". Your ban will expire in: %{expiration}.",
@@ -29,6 +39,23 @@
             "label_id": "Ban ID",
             "note_multiple_bans": "Note: you have more than one active ban on your identifiers.",
             "note_diff_license": "Note: the ban above was applied for another <code>license</code>, which means some of your IDs/HWIDs match the ones associated with that ban."
+        },
+        "embed": {
+            "title": "Player Banned",
+            "idban_description": "**Reason:** %{reason}\n**Expires:** %{expiration}\n\n**Identifiers:**\n```%{identifiers}```",
+            "playerban_description": "**Player:** %{player}\n**Reason:** %{reason}\n**Expires:** %{expiration}\n\n**Identifiers:**\n```%{identifiers}```"
+        }
+    },
+    "revocation_messages": {
+        "embed": {
+            "title": "Action Revoked",
+            "description": "**Action Type:** %{action} (`#%{actionId}`)\n**Target:** %{target}\n\n**Identifiers:**\n```%{identifiers}```"
+        }
+    },
+    "dm_messages": {
+        "embed": {
+            "title": "Admin DM Sent",
+            "description": "**Recipient:** %{player}\n**Message:**\n%{message}"
         }
     },
     "whitelist_messages": {

--- a/locale/es.json
+++ b/locale/es.json
@@ -14,7 +14,11 @@
     "kick_messages": {
         "everyone": "All players kicked: %{reason}.",
         "player": "You have been kicked: %{reason}.",
-        "unknown_reason": "for unknown reason"
+        "unknown_reason": "for unknown reason",
+        "embed": {
+            "title": "Player Kicked",
+            "playerban_description": "**Player:** %{player}\n**Reason:** %{reason}\n\n**Identifiers:**\n```%{identifiers}```"
+        }
     },
     "ban_messages": {
         "kick_temporary": "(%{author}) Has sido baneado del servidor por \"%{reason}\". Tu baneo expirará en: %{expiration}.",
@@ -29,6 +33,11 @@
             "label_id": "Ban ID",
             "note_multiple_bans": "Nota: tiene más de una prohibición activa en sus identificadores.",
             "note_diff_license": "Nota: el baneo de arriba fue aplicado para otra <code>license</code>, lo que significa que alguno de tus IDs/HWIDs coinciden con los del baneo asociado."
+        },
+        "embed": {
+            "title": "Player Banned",
+            "idban_description": "**Reason:** %{reason}\n**Expires:** %{expiration}\n\n**Identifiers:**\n```%{identifiers}```",
+            "playerban_description": "**Player:** %{player}\n**Reason:** %{reason}\n**Expires:** %{expiration}\n\n**Identifiers:**\n```%{identifiers}```"
         }
     },
     "whitelist_messages": {
@@ -362,6 +371,24 @@
                 "previous_ids": "Identificadores utilizados anteriormente",
                 "all_hwids": "All Hardware IDs"
             }
+        }
+    },
+    "warning_messages": {
+        "embed": {
+            "title": "Player Warned",
+            "description": "**Player:** %{player}\n**Reason:** %{reason}\n\n**Identifiers:**\n```%{identifiers}```"
+        }
+    },
+    "revocation_messages": {
+        "embed": {
+            "title": "Action Revoked",
+            "description": "**Action Type:** %{action} (`#%{actionId}`)\n**Target:** %{target}\n\n**Identifiers:**\n```%{identifiers}```"
+        }
+    },
+    "dm_messages": {
+        "embed": {
+            "title": "Admin DM Sent",
+            "description": "**Recipient:** %{player}\n**Message:**\n%{message}"
         }
     }
 }

--- a/locale/et.json
+++ b/locale/et.json
@@ -14,7 +14,11 @@
     "kick_messages": {
         "everyone": "All players kicked: %{reason}.",
         "player": "You have been kicked: %{reason}.",
-        "unknown_reason": "for unknown reason"
+        "unknown_reason": "for unknown reason",
+        "embed": {
+            "title": "Player Kicked",
+            "playerban_description": "**Player:** %{player}\n**Reason:** %{reason}\n\n**Identifiers:**\n```%{identifiers}```"
+        }
     },
     "ban_messages": {
         "kick_temporary": "(%{author}) Teid on sellest serverist ajutiselt keelustatud \"%{reason}\" tõttu. Teie keelustamine aegub: %{expiration}.",
@@ -29,6 +33,11 @@
             "label_id": "Keelustuse ID",
             "note_multiple_bans": "Märkus. Teil on oma identifikaatoritele rohkem kui üks aktiivne keelustus.",
             "note_diff_license": "Note: the ban above was applied for another <code>license</code>, which means some of your IDs/HWIDs match the ones associated with that ban."
+        },
+        "embed": {
+            "title": "Player Banned",
+            "idban_description": "**Reason:** %{reason}\n**Expires:** %{expiration}\n\n**Identifiers:**\n```%{identifiers}```",
+            "playerban_description": "**Player:** %{player}\n**Reason:** %{reason}\n**Expires:** %{expiration}\n\n**Identifiers:**\n```%{identifiers}```"
         }
     },
     "whitelist_messages": {
@@ -362,6 +371,24 @@
                 "previous_ids": "Varem kasutatud identifikaatorid",
                 "all_hwids": "Kõik Hardware IDd"
             }
+        }
+    },
+    "warning_messages": {
+        "embed": {
+            "title": "Player Warned",
+            "description": "**Player:** %{player}\n**Reason:** %{reason}\n\n**Identifiers:**\n```%{identifiers}```"
+        }
+    },
+    "revocation_messages": {
+        "embed": {
+            "title": "Action Revoked",
+            "description": "**Action Type:** %{action} (`#%{actionId}`)\n**Target:** %{target}\n\n**Identifiers:**\n```%{identifiers}```"
+        }
+    },
+    "dm_messages": {
+        "embed": {
+            "title": "Admin DM Sent",
+            "description": "**Recipient:** %{player}\n**Message:**\n%{message}"
         }
     }
 }

--- a/locale/fa.json
+++ b/locale/fa.json
@@ -14,7 +14,11 @@
     "kick_messages": {
         "everyone": "همه بازیکنان اخراج شدند: %{reason}.",
         "player": "شما اخراج شدید: %{reason}.",
-        "unknown_reason": "به دلیل نامشخص"
+        "unknown_reason": "به دلیل نامشخص",
+        "embed": {
+            "title": "Player Kicked",
+            "playerban_description": "**Player:** %{player}\n**Reason:** %{reason}\n\n**Identifiers:**\n```%{identifiers}```"
+        }
     },
     "ban_messages": {
         "kick_temporary": "(%{author}) شما از این سرور بن شدید، به دلیل: \"%{reason}\". اتمام بن شما: %{expiration}.",
@@ -29,6 +33,11 @@
             "label_id": "شناسه بن",
             "note_multiple_bans": "توجه: شما بیش از یک بن فعال در شناسه‌های خود دارید.",
             "note_diff_license": "توجه: بن فوق برای <code>license</code> دیگری اعمال شده است، به این معنی که برخی از شناسه‌ها/HWIDهای شما با موارد مرتبط با آن بن مطابقت دارند."
+        },
+        "embed": {
+            "title": "Player Banned",
+            "idban_description": "**Reason:** %{reason}\n**Expires:** %{expiration}\n\n**Identifiers:**\n```%{identifiers}```",
+            "playerban_description": "**Player:** %{player}\n**Reason:** %{reason}\n**Expires:** %{expiration}\n\n**Identifiers:**\n```%{identifiers}```"
         }
     },
     "whitelist_messages": {
@@ -362,6 +371,24 @@
                 "previous_ids": "شناسه‌های استفاده شده قبلی",
                 "all_hwids": "همه شناسه‌های سخت‌افزاری"
             }
+        }
+    },
+    "warning_messages": {
+        "embed": {
+            "title": "Player Warned",
+            "description": "**Player:** %{player}\n**Reason:** %{reason}\n\n**Identifiers:**\n```%{identifiers}```"
+        }
+    },
+    "revocation_messages": {
+        "embed": {
+            "title": "Action Revoked",
+            "description": "**Action Type:** %{action} (`#%{actionId}`)\n**Target:** %{target}\n\n**Identifiers:**\n```%{identifiers}```"
+        }
+    },
+    "dm_messages": {
+        "embed": {
+            "title": "Admin DM Sent",
+            "description": "**Recipient:** %{player}\n**Message:**\n%{message}"
         }
     }
 }

--- a/locale/fi.json
+++ b/locale/fi.json
@@ -14,7 +14,11 @@
     "kick_messages": {
         "everyone": "All players kicked: %{reason}.",
         "player": "You have been kicked: %{reason}.",
-        "unknown_reason": "for unknown reason"
+        "unknown_reason": "for unknown reason",
+        "embed": {
+            "title": "Player Kicked",
+            "playerban_description": "**Player:** %{player}\n**Reason:** %{reason}\n\n**Identifiers:**\n```%{identifiers}```"
+        }
     },
     "ban_messages": {
         "kick_temporary": "(%{author}) Olet saanut porttikiellon palvelimelle. Porttikiellon syy: \"%{reason}\". Porttikielto päättyy: %{expiration}.",
@@ -29,6 +33,11 @@
             "label_id": "Porttikiellon ID",
             "note_multiple_bans": "Huom: you have more than one active ban on your identifiers.",
             "note_diff_license": "Note: the ban above was applied for another <code>license</code>, which means some of your IDs/HWIDs match the ones associated with that ban."
+        },
+        "embed": {
+            "title": "Player Banned",
+            "idban_description": "**Reason:** %{reason}\n**Expires:** %{expiration}\n\n**Identifiers:**\n```%{identifiers}```",
+            "playerban_description": "**Player:** %{player}\n**Reason:** %{reason}\n**Expires:** %{expiration}\n\n**Identifiers:**\n```%{identifiers}```"
         }
     },
     "whitelist_messages": {
@@ -362,6 +371,24 @@
                 "previous_ids": "Aiemmin käytetyt tunnisteet",
                 "all_hwids": "All Hardware IDs"
             }
+        }
+    },
+    "warning_messages": {
+        "embed": {
+            "title": "Player Warned",
+            "description": "**Player:** %{player}\n**Reason:** %{reason}\n\n**Identifiers:**\n```%{identifiers}```"
+        }
+    },
+    "revocation_messages": {
+        "embed": {
+            "title": "Action Revoked",
+            "description": "**Action Type:** %{action} (`#%{actionId}`)\n**Target:** %{target}\n\n**Identifiers:**\n```%{identifiers}```"
+        }
+    },
+    "dm_messages": {
+        "embed": {
+            "title": "Admin DM Sent",
+            "description": "**Recipient:** %{player}\n**Message:**\n%{message}"
         }
     }
 }

--- a/locale/fr.json
+++ b/locale/fr.json
@@ -14,7 +14,11 @@
     "kick_messages": {
         "everyone": "All players kicked: %{reason}.",
         "player": "You have been kicked: %{reason}.",
-        "unknown_reason": "for unknown reason"
+        "unknown_reason": "for unknown reason",
+        "embed": {
+            "title": "Joueur expulsé",
+            "playerban_description": "**Joueur :** %{player}\n**Raison :** %{reason}\n\n**Identifiants :**\n```%{identifiers}```"
+        }
     },
     "ban_messages": {
         "kick_temporary": "(%{author}) Vous avez été banni pour: \"%{reason}\". Votre bannissement expirera dans: %{expiration}.",
@@ -29,6 +33,11 @@
             "label_id": "ID de sanction",
             "note_multiple_bans": "Note : vous avez plus d'un bannissement sur votre identifiant.",
             "note_diff_license": "Note: the ban above was applied for another <code>license</code>, which means some of your IDs/HWIDs match the ones associated with that ban."
+        },
+        "embed": {
+            "title": "Joueur banni",
+            "idban_description": "**Raison :** %{reason}\n**Expiration :** %{expiration}\n\n**Identifiants :**\n```%{identifiers}```",
+            "playerban_description": "**Joueur :** %{player}\n**Raison :** %{reason}\n**Expiration :** %{expiration}\n\n**Identifiants :**\n```%{identifiers}```"
         }
     },
     "whitelist_messages": {
@@ -362,6 +371,24 @@
                 "previous_ids": "Précedents identifiants",
                 "all_hwids": "All Hardware IDs"
             }
+        }
+    },
+    "warning_messages": {
+        "embed": {
+            "title": "Joueur averti",
+            "description": "**Joueur :** %{player}\n**Raison :** %{reason}\n\n**Identifiants :**\n```%{identifiers}```"
+        }
+    },
+    "revocation_messages": {
+        "embed": {
+            "title": "Sanction annulée",
+            "description": "**Type d'action :** %{action} (`#%{actionId}`)\n**Cible :** %{target}\n\n**Identifiants :**\n```%{identifiers}```"
+        }
+    },
+    "dm_messages": {
+        "embed": {
+            "title": "Message privé admin envoyé",
+            "description": "**Expéditeur :** %{author}\n**Destinataire :** %{player}\n\n**Message :**\n%{message}\n\n**Identifiants du destinataire :**\n```%{identifiers}```"
         }
     }
 }

--- a/locale/fr.json
+++ b/locale/fr.json
@@ -388,7 +388,7 @@
     "dm_messages": {
         "embed": {
             "title": "Message privé admin envoyé",
-            "description": "**Expéditeur :** %{author}\n**Destinataire :** %{player}\n\n**Message :**\n%{message}\n\n**Identifiants du destinataire :**\n```%{identifiers}```"
+            "description": "**Destinataire :** %{player}\n\n**Message :**\n%{message}"
         }
     }
 }

--- a/locale/hr.json
+++ b/locale/hr.json
@@ -14,7 +14,11 @@
     "kick_messages": {
         "everyone": "Svi igrači izbačeni: %{reason}.",
         "player": "Izbačen si: %{reason}.",
-        "unknown_reason": "iz nepoznatog razloga"
+        "unknown_reason": "iz nepoznatog razloga",
+        "embed": {
+            "title": "Player Kicked",
+            "playerban_description": "**Player:** %{player}\n**Reason:** %{reason}\n\n**Identifiers:**\n```%{identifiers}```"
+        }
     },
     "ban_messages": {
         "kick_temporary": "(%{author}) Zabranjeni ste sa servera zbog \"%{reason}\". Vaša zabrana ističe za: %{expiration}.",
@@ -29,6 +33,11 @@
             "label_id": "ID zabrane",
             "note_multiple_bans": "Poruka: Imaš više od jedne zabrane na ovom profilu.",
             "note_diff_license": "Poruka: Gornja zabrana je stavljen na <code>license</code>, što znači da jedan od tvojih IDova/HWIDova se slažu sa tim koji ima zabranu."
+        },
+        "embed": {
+            "title": "Player Banned",
+            "idban_description": "**Reason:** %{reason}\n**Expires:** %{expiration}\n\n**Identifiers:**\n```%{identifiers}```",
+            "playerban_description": "**Player:** %{player}\n**Reason:** %{reason}\n**Expires:** %{expiration}\n\n**Identifiers:**\n```%{identifiers}```"
         }
     },
     "whitelist_messages": {
@@ -362,6 +371,24 @@
                 "previous_ids": "Prijašnji igračevi profili",
                 "all_hwids": "Svi HWID-ovi"
             }
+        }
+    },
+    "warning_messages": {
+        "embed": {
+            "title": "Player Warned",
+            "description": "**Player:** %{player}\n**Reason:** %{reason}\n\n**Identifiers:**\n```%{identifiers}```"
+        }
+    },
+    "revocation_messages": {
+        "embed": {
+            "title": "Action Revoked",
+            "description": "**Action Type:** %{action} (`#%{actionId}`)\n**Target:** %{target}\n\n**Identifiers:**\n```%{identifiers}```"
+        }
+    },
+    "dm_messages": {
+        "embed": {
+            "title": "Admin DM Sent",
+            "description": "**Recipient:** %{player}\n**Message:**\n%{message}"
         }
     }
 }

--- a/locale/hu.json
+++ b/locale/hu.json
@@ -14,7 +14,11 @@
     "kick_messages": {
         "everyone": "All players kicked: %{reason}.",
         "player": "You have been kicked: %{reason}.",
-        "unknown_reason": "for unknown reason"
+        "unknown_reason": "for unknown reason",
+        "embed": {
+            "title": "Player Kicked",
+            "playerban_description": "**Player:** %{player}\n**Reason:** %{reason}\n\n**Identifiers:**\n```%{identifiers}```"
+        }
     },
     "ban_messages": {
         "kick_temporary": "(%{author}) Ki lettél tiltva a szerverről. Indok: \"%{reason}\". Lejár: %{expiration}.",
@@ -29,6 +33,11 @@
             "label_id": "Kitiltás ID",
             "note_multiple_bans": "Figyelem: Több mint egy aktív kitiltásod van ezen a fiókon.",
             "note_diff_license": "Megjegyzés: a kitiltás a <code>license</code> miatt van, ami azt jelenti, hogy néhány azonosítód/hardver azonosítód egyezik a kiltiltásban lévő adatokkal."
+        },
+        "embed": {
+            "title": "Player Banned",
+            "idban_description": "**Reason:** %{reason}\n**Expires:** %{expiration}\n\n**Identifiers:**\n```%{identifiers}```",
+            "playerban_description": "**Player:** %{player}\n**Reason:** %{reason}\n**Expires:** %{expiration}\n\n**Identifiers:**\n```%{identifiers}```"
         }
     },
     "whitelist_messages": {
@@ -362,6 +371,24 @@
                 "previous_ids": "Előző azonosítók",
                 "all_hwids": "Összes hardver ID"
             }
+        }
+    },
+    "warning_messages": {
+        "embed": {
+            "title": "Player Warned",
+            "description": "**Player:** %{player}\n**Reason:** %{reason}\n\n**Identifiers:**\n```%{identifiers}```"
+        }
+    },
+    "revocation_messages": {
+        "embed": {
+            "title": "Action Revoked",
+            "description": "**Action Type:** %{action} (`#%{actionId}`)\n**Target:** %{target}\n\n**Identifiers:**\n```%{identifiers}```"
+        }
+    },
+    "dm_messages": {
+        "embed": {
+            "title": "Admin DM Sent",
+            "description": "**Recipient:** %{player}\n**Message:**\n%{message}"
         }
     }
 }

--- a/locale/id.json
+++ b/locale/id.json
@@ -14,7 +14,11 @@
     "kick_messages": {
         "everyone": "Semua pemain dikeluarkan: %{reason}.",
         "player": "Anda telah dikeluarkan: %{reason}.",
-        "unknown_reason": "karena alasan yang tidak diketahui"
+        "unknown_reason": "karena alasan yang tidak diketahui",
+        "embed": {
+            "title": "Player Kicked",
+            "playerban_description": "**Player:** %{player}\n**Reason:** %{reason}\n\n**Identifiers:**\n```%{identifiers}```"
+        }
     },
     "ban_messages": {
         "kick_temporary": "(%{author}) Anda telah diblokir dari server ini karena \"%{reason}\". Blokir Anda akan berakhir dalam: %{expiration}.",
@@ -29,6 +33,11 @@
             "label_id": "ID Blokir",
             "note_multiple_bans": "Catatan: Anda memiliki lebih dari satu blokir aktif pada identitas Anda.",
             "note_diff_license": "Catatan: blokir di atas diterapkan untuk <code>license</code> yang berbeda, yang berarti beberapa ID/HWID Anda cocok dengan yang terkait dengan blokir tersebut."
+        },
+        "embed": {
+            "title": "Player Banned",
+            "idban_description": "**Reason:** %{reason}\n**Expires:** %{expiration}\n\n**Identifiers:**\n```%{identifiers}```",
+            "playerban_description": "**Player:** %{player}\n**Reason:** %{reason}\n**Expires:** %{expiration}\n\n**Identifiers:**\n```%{identifiers}```"
         }
     },
     "whitelist_messages": {
@@ -362,6 +371,24 @@
                 "helper_text": "Pilih durasi",
                 "submit": "Terapkan ban"
             }
+        }
+    },
+    "warning_messages": {
+        "embed": {
+            "title": "Player Warned",
+            "description": "**Player:** %{player}\n**Reason:** %{reason}\n\n**Identifiers:**\n```%{identifiers}```"
+        }
+    },
+    "revocation_messages": {
+        "embed": {
+            "title": "Action Revoked",
+            "description": "**Action Type:** %{action} (`#%{actionId}`)\n**Target:** %{target}\n\n**Identifiers:**\n```%{identifiers}```"
+        }
+    },
+    "dm_messages": {
+        "embed": {
+            "title": "Admin DM Sent",
+            "description": "**Recipient:** %{player}\n**Message:**\n%{message}"
         }
     }
 }

--- a/locale/it.json
+++ b/locale/it.json
@@ -14,7 +14,11 @@
     "kick_messages": {
         "everyone": "All players kicked: %{reason}.",
         "player": "You have been kicked: %{reason}.",
-        "unknown_reason": "for unknown reason"
+        "unknown_reason": "for unknown reason",
+        "embed": {
+            "title": "Player Kicked",
+            "playerban_description": "**Player:** %{player}\n**Reason:** %{reason}\n\n**Identifiers:**\n```%{identifiers}```"
+        }
     },
     "ban_messages": {
         "kick_temporary": "(%{author}) Sei stato bannato da questo server per \"%{reason}\". Il tuo ban scadrà in: %{expiration}.",
@@ -29,6 +33,11 @@
             "label_id": "ID Ban",
             "note_multiple_bans": "Nota: hai piu di un ban sui tuoi identificativi.",
             "note_diff_license": "Note: the ban above was applied for another <code>license</code>, which means some of your IDs/HWIDs match the ones associated with that ban."
+        },
+        "embed": {
+            "title": "Player Banned",
+            "idban_description": "**Reason:** %{reason}\n**Expires:** %{expiration}\n\n**Identifiers:**\n```%{identifiers}```",
+            "playerban_description": "**Player:** %{player}\n**Reason:** %{reason}\n**Expires:** %{expiration}\n\n**Identifiers:**\n```%{identifiers}```"
         }
     },
     "whitelist_messages": {
@@ -362,6 +371,24 @@
                 "previous_ids": "Identificativi usati precedentemente",
                 "all_hwids": "All Hardware IDs"
             }
+        }
+    },
+    "warning_messages": {
+        "embed": {
+            "title": "Player Warned",
+            "description": "**Player:** %{player}\n**Reason:** %{reason}\n\n**Identifiers:**\n```%{identifiers}```"
+        }
+    },
+    "revocation_messages": {
+        "embed": {
+            "title": "Action Revoked",
+            "description": "**Action Type:** %{action} (`#%{actionId}`)\n**Target:** %{target}\n\n**Identifiers:**\n```%{identifiers}```"
+        }
+    },
+    "dm_messages": {
+        "embed": {
+            "title": "Admin DM Sent",
+            "description": "**Recipient:** %{player}\n**Message:**\n%{message}"
         }
     }
 }

--- a/locale/ja.json
+++ b/locale/ja.json
@@ -14,7 +14,11 @@
     "kick_messages": {
         "everyone": "All players kicked: %{reason}.",
         "player": "You have been kicked: %{reason}.",
-        "unknown_reason": "for unknown reason"
+        "unknown_reason": "for unknown reason",
+        "embed": {
+            "title": "Player Kicked",
+            "playerban_description": "**Player:** %{player}\n**Reason:** %{reason}\n\n**Identifiers:**\n```%{identifiers}```"
+        }
     },
     "ban_messages": {
         "kick_temporary": "(%{author}) あなたは次の理由によりBANされました \"%{reason}\" BAN期間: %{expiration}",
@@ -29,6 +33,11 @@
             "label_id": "BAN ID",
             "note_multiple_bans": "注: あなたのIDには、有効なBANが複数記録されています。",
             "note_diff_license": "注: 上記のBANは別の<code>ライセンス</code>に対して適用されたもので、あなたのID/HWIDの一部がそのBANに関連するものと一致することを意味します。"
+        },
+        "embed": {
+            "title": "Player Banned",
+            "idban_description": "**Reason:** %{reason}\n**Expires:** %{expiration}\n\n**Identifiers:**\n```%{identifiers}```",
+            "playerban_description": "**Player:** %{player}\n**Reason:** %{reason}\n**Expires:** %{expiration}\n\n**Identifiers:**\n```%{identifiers}```"
         }
     },
     "whitelist_messages": {
@@ -362,6 +371,24 @@
                 "helper_text": "期間を選択してください",
                 "submit": "BANを適用"
             }
+        }
+    },
+    "warning_messages": {
+        "embed": {
+            "title": "Player Warned",
+            "description": "**Player:** %{player}\n**Reason:** %{reason}\n\n**Identifiers:**\n```%{identifiers}```"
+        }
+    },
+    "revocation_messages": {
+        "embed": {
+            "title": "Action Revoked",
+            "description": "**Action Type:** %{action} (`#%{actionId}`)\n**Target:** %{target}\n\n**Identifiers:**\n```%{identifiers}```"
+        }
+    },
+    "dm_messages": {
+        "embed": {
+            "title": "Admin DM Sent",
+            "description": "**Recipient:** %{player}\n**Message:**\n%{message}"
         }
     }
 }

--- a/locale/lt.json
+++ b/locale/lt.json
@@ -14,7 +14,11 @@
     "kick_messages": {
         "everyone": "All players kicked: %{reason}.",
         "player": "You have been kicked: %{reason}.",
-        "unknown_reason": "for unknown reason"
+        "unknown_reason": "for unknown reason",
+        "embed": {
+            "title": "Player Kicked",
+            "playerban_description": "**Player:** %{player}\n**Reason:** %{reason}\n\n**Identifiers:**\n```%{identifiers}```"
+        }
     },
     "ban_messages": {
         "kick_temporary": "(%{author}) Buvote užblokuotas iš serverio dėl \"%{reason}\". Blokavimas bus baigtas: %{expiration}.",
@@ -29,6 +33,11 @@
             "label_id": "Užblokavimo ID",
             "note_multiple_bans": "P.S. Tu turi daugiau nei vieną užblokavimą ant savo identifikatorių",
             "note_diff_license": "Prierašas: šis užblokavimas skirtas kitai <code>licenzijai</code>, tai reiškią jūsų kai kurie IDs/HWIDs sutampa su esančiais tame užblokavime"
+        },
+        "embed": {
+            "title": "Player Banned",
+            "idban_description": "**Reason:** %{reason}\n**Expires:** %{expiration}\n\n**Identifiers:**\n```%{identifiers}```",
+            "playerban_description": "**Player:** %{player}\n**Reason:** %{reason}\n**Expires:** %{expiration}\n\n**Identifiers:**\n```%{identifiers}```"
         }
     },
     "whitelist_messages": {
@@ -362,6 +371,24 @@
                 "previous_ids": "Ankščiau Naudoti Identifikatoriai",
                 "all_hwids": "Visi HWID Identifikatoriai"
             }
+        }
+    },
+    "warning_messages": {
+        "embed": {
+            "title": "Player Warned",
+            "description": "**Player:** %{player}\n**Reason:** %{reason}\n\n**Identifiers:**\n```%{identifiers}```"
+        }
+    },
+    "revocation_messages": {
+        "embed": {
+            "title": "Action Revoked",
+            "description": "**Action Type:** %{action} (`#%{actionId}`)\n**Target:** %{target}\n\n**Identifiers:**\n```%{identifiers}```"
+        }
+    },
+    "dm_messages": {
+        "embed": {
+            "title": "Admin DM Sent",
+            "description": "**Recipient:** %{player}\n**Message:**\n%{message}"
         }
     }
 }

--- a/locale/lv.json
+++ b/locale/lv.json
@@ -14,7 +14,11 @@
     "kick_messages": {
         "everyone": "Visi spēlētāji tika izmesti: %{reason}.",
         "player": "Tu tiki izmests no servera: %{reason}.",
-        "unknown_reason": "nezināma iemesla dēļ"
+        "unknown_reason": "nezināma iemesla dēļ",
+        "embed": {
+            "title": "Player Kicked",
+            "playerban_description": "**Player:** %{player}\n**Reason:** %{reason}\n\n**Identifiers:**\n```%{identifiers}```"
+        }
     },
     "ban_messages": {
         "kick_temporary": "(%{author}) Tu esi uz laiku bloķēts no šī servera par \"%{reason}\". Tava bloķēšana beigsies pēc: %{expiration}.",
@@ -29,6 +33,11 @@
             "label_id": "Ban ID",
             "note_multiple_bans": "Piezīme: Tev ir vairāk nekā viena aktīva bloķēšana taviem identifikatoriem.",
             "note_diff_license": "Piezīme: augstāk redzamā bloķēšana tika piemērota citai <code>license</code>, kas nozīmē, ka daži no taviem ID/HWID sakrīt ar tiem, kas saistīti ar šo bloķēšanu."
+        },
+        "embed": {
+            "title": "Player Banned",
+            "idban_description": "**Reason:** %{reason}\n**Expires:** %{expiration}\n\n**Identifiers:**\n```%{identifiers}```",
+            "playerban_description": "**Player:** %{player}\n**Reason:** %{reason}\n**Expires:** %{expiration}\n\n**Identifiers:**\n```%{identifiers}```"
         }
     },
     "whitelist_messages": {
@@ -362,6 +371,24 @@
                 "previous_ids": "Iepriekš izmantotie identifikatori",
                 "all_hwids": "Visi HWID ID"
             }
+        }
+    },
+    "warning_messages": {
+        "embed": {
+            "title": "Player Warned",
+            "description": "**Player:** %{player}\n**Reason:** %{reason}\n\n**Identifiers:**\n```%{identifiers}```"
+        }
+    },
+    "revocation_messages": {
+        "embed": {
+            "title": "Action Revoked",
+            "description": "**Action Type:** %{action} (`#%{actionId}`)\n**Target:** %{target}\n\n**Identifiers:**\n```%{identifiers}```"
+        }
+    },
+    "dm_messages": {
+        "embed": {
+            "title": "Admin DM Sent",
+            "description": "**Recipient:** %{player}\n**Message:**\n%{message}"
         }
     }
 }

--- a/locale/mn.json
+++ b/locale/mn.json
@@ -14,7 +14,11 @@
     "kick_messages": {
         "everyone": "All players kicked: %{reason}.",
         "player": "You have been kicked: %{reason}.",
-        "unknown_reason": "for unknown reason"
+        "unknown_reason": "for unknown reason",
+        "embed": {
+            "title": "Player Kicked",
+            "playerban_description": "**Player:** %{player}\n**Reason:** %{reason}\n\n**Identifiers:**\n```%{identifiers}```"
+        }
     },
     "ban_messages": {
         "kick_temporary": "(%{author}) Таны нэвтрэх эрх хязгаарлагдсан байна. Шалтгаан: \"%{reason}\". Хязгаарлагдах хугацаа: %{expiration}.",
@@ -29,6 +33,11 @@
             "label_id": "БАН КОД",
             "note_multiple_bans": "Сануулга: та хэтэрхий олон BAN -тай байна.",
             "note_diff_license": "Сануулга: таны <code>license</code> Rockstar ID, HWID BAN буюу их хавтангаар эрхээ хязгаарлуулсан байна."
+        },
+        "embed": {
+            "title": "Player Banned",
+            "idban_description": "**Reason:** %{reason}\n**Expires:** %{expiration}\n\n**Identifiers:**\n```%{identifiers}```",
+            "playerban_description": "**Player:** %{player}\n**Reason:** %{reason}\n**Expires:** %{expiration}\n\n**Identifiers:**\n```%{identifiers}```"
         }
     },
     "whitelist_messages": {
@@ -362,6 +371,24 @@
                 "helper_text": "Хугацаа сонгоно уу",
                 "submit": "Хоригийг эхлүүлэх"
             }
+        }
+    },
+    "warning_messages": {
+        "embed": {
+            "title": "Player Warned",
+            "description": "**Player:** %{player}\n**Reason:** %{reason}\n\n**Identifiers:**\n```%{identifiers}```"
+        }
+    },
+    "revocation_messages": {
+        "embed": {
+            "title": "Action Revoked",
+            "description": "**Action Type:** %{action} (`#%{actionId}`)\n**Target:** %{target}\n\n**Identifiers:**\n```%{identifiers}```"
+        }
+    },
+    "dm_messages": {
+        "embed": {
+            "title": "Admin DM Sent",
+            "description": "**Recipient:** %{player}\n**Message:**\n%{message}"
         }
     }
 }

--- a/locale/ne.json
+++ b/locale/ne.json
@@ -14,7 +14,11 @@
     "kick_messages": {
         "everyone": "सबैलाई निकालियो कारण: %{reason}।",
         "player": "तिमीलाई निकालियो कारण: %{reason}।",
-        "unknown_reason": "अज्ञात कारण"
+        "unknown_reason": "अज्ञात कारण",
+        "embed": {
+            "title": "Player Kicked",
+            "playerban_description": "**Player:** %{player}\n**Reason:** %{reason}\n\n**Identifiers:**\n```%{identifiers}```"
+        }
     },
     "ban_messages": {
         "kick_temporary": "(%{author}) तपाईंलाई \"%{reason}\" को कारणले यो सर्भरबाट प्रतिबन्धित गरिएको छ। तपाईंको प्रतिबन्ध %{expiration} मा समाप्त हुनेछ।",
@@ -29,6 +33,11 @@
             "label_id": "प्रतिबन्ध आईडी",
             "note_multiple_bans": "नोट: तपाईंको पहिचानकर्ताहरूमा एकभन्दा बढी सक्रिय प्रतिबन्ध छन्।",
             "note_diff_license": "नोट: माथिको प्रतिबन्ध अर्को <code>लाइसेन्स</code>को लागि लागू गरिएको थियो, जसको अर्थ तपाईंका केही आईडी/HWIDहरू त्यो प्रतिबन्धसँग सम्बन्धित भएकाहरूसँग मेल खान्छन्।"
+        },
+        "embed": {
+            "title": "Player Banned",
+            "idban_description": "**Reason:** %{reason}\n**Expires:** %{expiration}\n\n**Identifiers:**\n```%{identifiers}```",
+            "playerban_description": "**Player:** %{player}\n**Reason:** %{reason}\n**Expires:** %{expiration}\n\n**Identifiers:**\n```%{identifiers}```"
         }
     },
     "whitelist_messages": {
@@ -362,6 +371,24 @@
                 "helper_text": "कृपया एक अवधि चयन गर्नुहोस्",
                 "submit": "प्रतिबन्ध लागू गर्नुहोस्"
             }
+        }
+    },
+    "warning_messages": {
+        "embed": {
+            "title": "Player Warned",
+            "description": "**Player:** %{player}\n**Reason:** %{reason}\n\n**Identifiers:**\n```%{identifiers}```"
+        }
+    },
+    "revocation_messages": {
+        "embed": {
+            "title": "Action Revoked",
+            "description": "**Action Type:** %{action} (`#%{actionId}`)\n**Target:** %{target}\n\n**Identifiers:**\n```%{identifiers}```"
+        }
+    },
+    "dm_messages": {
+        "embed": {
+            "title": "Admin DM Sent",
+            "description": "**Recipient:** %{player}\n**Message:**\n%{message}"
         }
     }
 }

--- a/locale/nl.json
+++ b/locale/nl.json
@@ -14,7 +14,11 @@
     "kick_messages": {
         "everyone": "Alle spelers gekicked: %{reason}.",
         "player": "Je bent gekicked: %{reason}.",
-        "unknown_reason": "voor onbekende reden"
+        "unknown_reason": "voor onbekende reden",
+        "embed": {
+            "title": "Player Kicked",
+            "playerban_description": "**Player:** %{player}\n**Reason:** %{reason}\n\n**Identifiers:**\n```%{identifiers}```"
+        }
     },
     "ban_messages": {
         "kick_temporary": "(%{author}) Je bent tijdelijk verbannen van deze server met de reden: \"%{reason}\". Je ban zal vervallen over: %{expiration}.",
@@ -29,6 +33,11 @@
             "label_id": "Ban ID",
             "note_multiple_bans": "Opmerking: U hebt meer dan één actieve ban op uw Identifiers.",
             "note_diff_license": "Opmerking: de bovenstaande ban werd toegepast voor een andere <code>license</code>, wat betekent dat sommige van jouw IDs/HWIDs matchen met degene die zijn geassocieerd met die ban."
+        },
+        "embed": {
+            "title": "Player Banned",
+            "idban_description": "**Reason:** %{reason}\n**Expires:** %{expiration}\n\n**Identifiers:**\n```%{identifiers}```",
+            "playerban_description": "**Player:** %{player}\n**Reason:** %{reason}\n**Expires:** %{expiration}\n\n**Identifiers:**\n```%{identifiers}```"
         }
     },
     "whitelist_messages": {
@@ -362,6 +371,24 @@
                 "previous_ids": "Eerder gebruikte Identifiers",
                 "all_hwids": "Alle Hardware IDs"
             }
+        }
+    },
+    "warning_messages": {
+        "embed": {
+            "title": "Player Warned",
+            "description": "**Player:** %{player}\n**Reason:** %{reason}\n\n**Identifiers:**\n```%{identifiers}```"
+        }
+    },
+    "revocation_messages": {
+        "embed": {
+            "title": "Action Revoked",
+            "description": "**Action Type:** %{action} (`#%{actionId}`)\n**Target:** %{target}\n\n**Identifiers:**\n```%{identifiers}```"
+        }
+    },
+    "dm_messages": {
+        "embed": {
+            "title": "Admin DM Sent",
+            "description": "**Recipient:** %{player}\n**Message:**\n%{message}"
         }
     }
 }

--- a/locale/no.json
+++ b/locale/no.json
@@ -14,7 +14,11 @@
     "kick_messages": {
         "everyone": "Alle spillere ble sparket ut: %{reason}.",
         "player": "Du har blitt sparket ut: %{reason}.",
-        "unknown_reason": "av en ukjent grunn"
+        "unknown_reason": "av en ukjent grunn",
+        "embed": {
+            "title": "Player Kicked",
+            "playerban_description": "**Player:** %{player}\n**Reason:** %{reason}\n\n**Identifiers:**\n```%{identifiers}```"
+        }
     },
     "ban_messages": {
         "kick_temporary": "(%{author}) Du har blitt utestengt fra denne serveren grunnet \"%{reason}\". Utestengelsen din oppheves om: %{expiration}.",
@@ -29,6 +33,11 @@
             "label_id": "Utestengelse ID",
             "note_multiple_bans": "NB: du har flere aktive utestengelser.",
             "note_diff_license": "NB: utestengelsen over var tilegnet en annen <code>license</code>, dette betyr at en eller flere av dine identifikatorer/maskinvare-ID'er er assosiert med den utestengelsen."
+        },
+        "embed": {
+            "title": "Player Banned",
+            "idban_description": "**Reason:** %{reason}\n**Expires:** %{expiration}\n\n**Identifiers:**\n```%{identifiers}```",
+            "playerban_description": "**Player:** %{player}\n**Reason:** %{reason}\n**Expires:** %{expiration}\n\n**Identifiers:**\n```%{identifiers}```"
         }
     },
     "whitelist_messages": {
@@ -362,6 +371,24 @@
                 "helper_text": "Venligst spesifiser varigheten",
                 "submit": "Utesteng"
             }
+        }
+    },
+    "warning_messages": {
+        "embed": {
+            "title": "Player Warned",
+            "description": "**Player:** %{player}\n**Reason:** %{reason}\n\n**Identifiers:**\n```%{identifiers}```"
+        }
+    },
+    "revocation_messages": {
+        "embed": {
+            "title": "Action Revoked",
+            "description": "**Action Type:** %{action} (`#%{actionId}`)\n**Target:** %{target}\n\n**Identifiers:**\n```%{identifiers}```"
+        }
+    },
+    "dm_messages": {
+        "embed": {
+            "title": "Admin DM Sent",
+            "description": "**Recipient:** %{player}\n**Message:**\n%{message}"
         }
     }
 }

--- a/locale/pl.json
+++ b/locale/pl.json
@@ -14,7 +14,11 @@
     "kick_messages": {
         "everyone": "All players kicked: %{reason}.",
         "player": "You have been kicked: %{reason}.",
-        "unknown_reason": "for unknown reason"
+        "unknown_reason": "for unknown reason",
+        "embed": {
+            "title": "Player Kicked",
+            "playerban_description": "**Player:** %{player}\n**Reason:** %{reason}\n\n**Identifiers:**\n```%{identifiers}```"
+        }
     },
     "ban_messages": {
         "kick_temporary": "(%{author}) Zostałeś zbanowany na tym serwerze z powodu \"%{reason}\". Twój ban wygaśnie za: %{expiration}.",
@@ -29,6 +33,11 @@
             "label_id": "Identyfikator bana",
             "note_multiple_bans": "Uwaga: masz więcej niż jedną aktywną blokadę na swoje identyfikatory.",
             "note_diff_license": "Uwaga: powyższy ban został nadany na inną <code>licencję</code>, co oznacza że któryś z twoich identyfikatorów pokrywa się z tymi zbanowanymi."
+        },
+        "embed": {
+            "title": "Player Banned",
+            "idban_description": "**Reason:** %{reason}\n**Expires:** %{expiration}\n\n**Identifiers:**\n```%{identifiers}```",
+            "playerban_description": "**Player:** %{player}\n**Reason:** %{reason}\n**Expires:** %{expiration}\n\n**Identifiers:**\n```%{identifiers}```"
         }
     },
     "whitelist_messages": {
@@ -362,6 +371,24 @@
                 "previous_ids": "Wcześniej Używane Identyfikatory",
                 "all_hwids": "Wszystkie Identyfikatory HWID"
             }
+        }
+    },
+    "warning_messages": {
+        "embed": {
+            "title": "Player Warned",
+            "description": "**Player:** %{player}\n**Reason:** %{reason}\n\n**Identifiers:**\n```%{identifiers}```"
+        }
+    },
+    "revocation_messages": {
+        "embed": {
+            "title": "Action Revoked",
+            "description": "**Action Type:** %{action} (`#%{actionId}`)\n**Target:** %{target}\n\n**Identifiers:**\n```%{identifiers}```"
+        }
+    },
+    "dm_messages": {
+        "embed": {
+            "title": "Admin DM Sent",
+            "description": "**Recipient:** %{player}\n**Message:**\n%{message}"
         }
     }
 }

--- a/locale/pt.json
+++ b/locale/pt.json
@@ -14,7 +14,11 @@
     "kick_messages": {
         "everyone": "Todos os jogadores foram expulsos: %{reason}.",
         "player": "Você foi expulso: %{reason}.",
-        "unknown_reason": "razão desconhecida"
+        "unknown_reason": "razão desconhecida",
+        "embed": {
+            "title": "Player Kicked",
+            "playerban_description": "**Player:** %{player}\n**Reason:** %{reason}\n\n**Identifiers:**\n```%{identifiers}```"
+        }
     },
     "ban_messages": {
         "kick_temporary": "(%{author}) Você foi banido deste servidor por \"%{reason}\". Seu ban vai expirar em: %{expiration}.",
@@ -29,6 +33,11 @@
             "label_id": "ID do ban",
             "note_multiple_bans": "Nota: você tem mais de um ban ativo em seus ids.",
             "note_diff_license": "Nota: o ban acima foi aplicado em outra <code>license</code>, o que significa que um de seus IDs/HWIDs condiz com algum deste ban."
+        },
+        "embed": {
+            "title": "Player Banned",
+            "idban_description": "**Reason:** %{reason}\n**Expires:** %{expiration}\n\n**Identifiers:**\n```%{identifiers}```",
+            "playerban_description": "**Player:** %{player}\n**Reason:** %{reason}\n**Expires:** %{expiration}\n\n**Identifiers:**\n```%{identifiers}```"
         }
     },
     "whitelist_messages": {
@@ -362,6 +371,24 @@
                 "previous_ids": "IDs usados anteriormente",
                 "all_hwids": "Todos IDs de Hardware"
             }
+        }
+    },
+    "warning_messages": {
+        "embed": {
+            "title": "Player Warned",
+            "description": "**Player:** %{player}\n**Reason:** %{reason}\n\n**Identifiers:**\n```%{identifiers}```"
+        }
+    },
+    "revocation_messages": {
+        "embed": {
+            "title": "Action Revoked",
+            "description": "**Action Type:** %{action} (`#%{actionId}`)\n**Target:** %{target}\n\n**Identifiers:**\n```%{identifiers}```"
+        }
+    },
+    "dm_messages": {
+        "embed": {
+            "title": "Admin DM Sent",
+            "description": "**Recipient:** %{player}\n**Message:**\n%{message}"
         }
     }
 }

--- a/locale/ro.json
+++ b/locale/ro.json
@@ -14,7 +14,11 @@
     "kick_messages": {
         "everyone": "All players kicked: %{reason}.",
         "player": "You have been kicked: %{reason}.",
-        "unknown_reason": "for unknown reason"
+        "unknown_reason": "for unknown reason",
+        "embed": {
+            "title": "Player Kicked",
+            "playerban_description": "**Player:** %{player}\n**Reason:** %{reason}\n\n**Identifiers:**\n```%{identifiers}```"
+        }
     },
     "ban_messages": {
         "kick_temporary": "(%{author}) Ai fost interzis de pe acest server pentru \"%{reason}\". Interzicerea ta va expira în: %{expiration}.",
@@ -29,6 +33,11 @@
             "label_id": "Ban ID",
             "note_multiple_bans": "Note: you have more than one active ban on your identifiers.",
             "note_diff_license": "Note: the ban above was applied for another <code>license</code>, which means some of your IDs/HWIDs match the ones associated with that ban."
+        },
+        "embed": {
+            "title": "Player Banned",
+            "idban_description": "**Reason:** %{reason}\n**Expires:** %{expiration}\n\n**Identifiers:**\n```%{identifiers}```",
+            "playerban_description": "**Player:** %{player}\n**Reason:** %{reason}\n**Expires:** %{expiration}\n\n**Identifiers:**\n```%{identifiers}```"
         }
     },
     "whitelist_messages": {
@@ -362,6 +371,24 @@
                 "previous_ids": "Previously Used Identifiers",
                 "all_hwids": "All Hardware IDs"
             }
+        }
+    },
+    "warning_messages": {
+        "embed": {
+            "title": "Player Warned",
+            "description": "**Player:** %{player}\n**Reason:** %{reason}\n\n**Identifiers:**\n```%{identifiers}```"
+        }
+    },
+    "revocation_messages": {
+        "embed": {
+            "title": "Action Revoked",
+            "description": "**Action Type:** %{action} (`#%{actionId}`)\n**Target:** %{target}\n\n**Identifiers:**\n```%{identifiers}```"
+        }
+    },
+    "dm_messages": {
+        "embed": {
+            "title": "Admin DM Sent",
+            "description": "**Recipient:** %{player}\n**Message:**\n%{message}"
         }
     }
 }

--- a/locale/ru.json
+++ b/locale/ru.json
@@ -14,7 +14,11 @@
     "kick_messages": {
         "everyone": "All players kicked: %{reason}.",
         "player": "You have been kicked: %{reason}.",
-        "unknown_reason": "for unknown reason"
+        "unknown_reason": "for unknown reason",
+        "embed": {
+            "title": "Player Kicked",
+            "playerban_description": "**Player:** %{player}\n**Reason:** %{reason}\n\n**Identifiers:**\n```%{identifiers}```"
+        }
     },
     "ban_messages": {
         "kick_temporary": "(%{author}) Вы были заблокированы на этом сервере за \"%{reason}\". Срок вашей блокировки истекает в: %{expiration}.",
@@ -29,6 +33,11 @@
             "label_id": "Бан ID",
             "note_multiple_bans": "Примечание: у вас более одного активного запрета на ваши идентификаторы.",
             "note_diff_license": "Примечание: вышеуказанный запрет был применен для другой <code>license</code>, это означает, что некоторые из ваших идентификаторов/HWID совпадают с теми, которые связаны с этим запретом."
+        },
+        "embed": {
+            "title": "Player Banned",
+            "idban_description": "**Reason:** %{reason}\n**Expires:** %{expiration}\n\n**Identifiers:**\n```%{identifiers}```",
+            "playerban_description": "**Player:** %{player}\n**Reason:** %{reason}\n**Expires:** %{expiration}\n\n**Identifiers:**\n```%{identifiers}```"
         }
     },
     "whitelist_messages": {
@@ -362,6 +371,24 @@
                 "previous_ids": "Ранее использовавшиеся идентификаторы",
                 "all_hwids": "Все идентификаторы оборудования"
             }
+        }
+    },
+    "warning_messages": {
+        "embed": {
+            "title": "Player Warned",
+            "description": "**Player:** %{player}\n**Reason:** %{reason}\n\n**Identifiers:**\n```%{identifiers}```"
+        }
+    },
+    "revocation_messages": {
+        "embed": {
+            "title": "Action Revoked",
+            "description": "**Action Type:** %{action} (`#%{actionId}`)\n**Target:** %{target}\n\n**Identifiers:**\n```%{identifiers}```"
+        }
+    },
+    "dm_messages": {
+        "embed": {
+            "title": "Admin DM Sent",
+            "description": "**Recipient:** %{player}\n**Message:**\n%{message}"
         }
     }
 }

--- a/locale/sl.json
+++ b/locale/sl.json
@@ -14,7 +14,11 @@
     "kick_messages": {
         "everyone": "Vsi igralci so bili kick-ani: %{reason}.",
         "player": "Bili ste kick-ani: %{reason}.",
-        "unknown_reason": "iz neznanega razloga"
+        "unknown_reason": "iz neznanega razloga",
+        "embed": {
+            "title": "Player Kicked",
+            "playerban_description": "**Player:** %{player}\n**Reason:** %{reason}\n\n**Identifiers:**\n```%{identifiers}```"
+        }
     },
     "ban_messages": {
         "kick_temporary": "(%{author}) Bil si odstranjen iz strežnika zaradi \"%{reason}\". Tvoj BAN se izteče čez: %{expiration}.",
@@ -29,6 +33,11 @@
             "label_id": "Ban ID",
             "note_multiple_bans": "Opomba: Imate več kot en ban na vaših identifierjih.",
             "note_diff_license": "Opomba: zgoraj omenjen ban, je bil dodeljen drugi <code>licenci</code>, torej se tvoji in njihovi IDs/HWIDs, ki so povezani z banom, ujemajo."
+        },
+        "embed": {
+            "title": "Player Banned",
+            "idban_description": "**Reason:** %{reason}\n**Expires:** %{expiration}\n\n**Identifiers:**\n```%{identifiers}```",
+            "playerban_description": "**Player:** %{player}\n**Reason:** %{reason}\n**Expires:** %{expiration}\n\n**Identifiers:**\n```%{identifiers}```"
         }
     },
     "whitelist_messages": {
@@ -362,6 +371,24 @@
                 "previous_ids": "Prej uporabljeni identifierji",
                 "all_hwids": "Strojni IDs"
             }
+        }
+    },
+    "warning_messages": {
+        "embed": {
+            "title": "Player Warned",
+            "description": "**Player:** %{player}\n**Reason:** %{reason}\n\n**Identifiers:**\n```%{identifiers}```"
+        }
+    },
+    "revocation_messages": {
+        "embed": {
+            "title": "Action Revoked",
+            "description": "**Action Type:** %{action} (`#%{actionId}`)\n**Target:** %{target}\n\n**Identifiers:**\n```%{identifiers}```"
+        }
+    },
+    "dm_messages": {
+        "embed": {
+            "title": "Admin DM Sent",
+            "description": "**Recipient:** %{player}\n**Message:**\n%{message}"
         }
     }
 }

--- a/locale/sv.json
+++ b/locale/sv.json
@@ -14,7 +14,11 @@
     "kick_messages": {
         "everyone": "All players kicked: %{reason}.",
         "player": "You have been kicked: %{reason}.",
-        "unknown_reason": "for unknown reason"
+        "unknown_reason": "for unknown reason",
+        "embed": {
+            "title": "Player Kicked",
+            "playerban_description": "**Player:** %{player}\n**Reason:** %{reason}\n\n**Identifiers:**\n```%{identifiers}```"
+        }
     },
     "ban_messages": {
         "kick_temporary": "(%{author}) Du har blivit bannlyst från denna server på grund av \"%{reason}\". Din bannlysning går ut : %{expiration}.",
@@ -29,6 +33,11 @@
             "label_id": "Bannlysnings ID",
             "note_multiple_bans": "OBS Du kan vara bannlyst på flera identifikationer.",
             "note_diff_license": "Note: the ban above was applied for another <code>license</code>, which means some of your IDs/HWIDs match the ones associated with that ban."
+        },
+        "embed": {
+            "title": "Player Banned",
+            "idban_description": "**Reason:** %{reason}\n**Expires:** %{expiration}\n\n**Identifiers:**\n```%{identifiers}```",
+            "playerban_description": "**Player:** %{player}\n**Reason:** %{reason}\n**Expires:** %{expiration}\n\n**Identifiers:**\n```%{identifiers}```"
         }
     },
     "whitelist_messages": {
@@ -362,6 +371,24 @@
                 "previous_ids": "Tidigare använda identifikationer",
                 "all_hwids": "Alla hårdvaru identifikationer"
             }
+        }
+    },
+    "warning_messages": {
+        "embed": {
+            "title": "Player Warned",
+            "description": "**Player:** %{player}\n**Reason:** %{reason}\n\n**Identifiers:**\n```%{identifiers}```"
+        }
+    },
+    "revocation_messages": {
+        "embed": {
+            "title": "Action Revoked",
+            "description": "**Action Type:** %{action} (`#%{actionId}`)\n**Target:** %{target}\n\n**Identifiers:**\n```%{identifiers}```"
+        }
+    },
+    "dm_messages": {
+        "embed": {
+            "title": "Admin DM Sent",
+            "description": "**Recipient:** %{player}\n**Message:**\n%{message}"
         }
     }
 }

--- a/locale/th.json
+++ b/locale/th.json
@@ -14,7 +14,11 @@
     "kick_messages": {
         "everyone": "All players kicked: %{reason}.",
         "player": "You have been kicked: %{reason}.",
-        "unknown_reason": "for unknown reason"
+        "unknown_reason": "for unknown reason",
+        "embed": {
+            "title": "Player Kicked",
+            "playerban_description": "**Player:** %{player}\n**Reason:** %{reason}\n\n**Identifiers:**\n```%{identifiers}```"
+        }
     },
     "ban_messages": {
         "kick_temporary": "(%{author}) คุณถูกแบนจากเซิร์ฟเวอร์นี้เพราะ \"%{reason}\" การแบนของคุณจะหมดอายุใน: %{expiration}.",
@@ -29,6 +33,11 @@
             "label_id": "Ban ID",
             "note_multiple_bans": "Note: you have more than one active ban on your identifiers.",
             "note_diff_license": "Note: the ban above was applied for another <code>license</code>, which means some of your IDs/HWIDs match the ones associated with that ban."
+        },
+        "embed": {
+            "title": "Player Banned",
+            "idban_description": "**Reason:** %{reason}\n**Expires:** %{expiration}\n\n**Identifiers:**\n```%{identifiers}```",
+            "playerban_description": "**Player:** %{player}\n**Reason:** %{reason}\n**Expires:** %{expiration}\n\n**Identifiers:**\n```%{identifiers}```"
         }
     },
     "whitelist_messages": {
@@ -362,6 +371,24 @@
                 "previous_ids": "Previously Used Identifiers",
                 "all_hwids": "All Hardware IDs"
             }
+        }
+    },
+    "warning_messages": {
+        "embed": {
+            "title": "Player Warned",
+            "description": "**Player:** %{player}\n**Reason:** %{reason}\n\n**Identifiers:**\n```%{identifiers}```"
+        }
+    },
+    "revocation_messages": {
+        "embed": {
+            "title": "Action Revoked",
+            "description": "**Action Type:** %{action} (`#%{actionId}`)\n**Target:** %{target}\n\n**Identifiers:**\n```%{identifiers}```"
+        }
+    },
+    "dm_messages": {
+        "embed": {
+            "title": "Admin DM Sent",
+            "description": "**Recipient:** %{player}\n**Message:**\n%{message}"
         }
     }
 }

--- a/locale/tr.json
+++ b/locale/tr.json
@@ -14,7 +14,11 @@
     "kick_messages": {
         "everyone": "All players kicked: %{reason}.",
         "player": "You have been kicked: %{reason}.",
-        "unknown_reason": "for unknown reason"
+        "unknown_reason": "for unknown reason",
+        "embed": {
+            "title": "Player Kicked",
+            "playerban_description": "**Player:** %{player}\n**Reason:** %{reason}\n\n**Identifiers:**\n```%{identifiers}```"
+        }
     },
     "ban_messages": {
         "kick_temporary": "(%{author}) \"%{reason}\" sebebi ile bu sunucudan uzaklaştırıldın! Cezanın bitmesine kalan süre: %{expiration}.",
@@ -29,6 +33,11 @@
             "label_id": "Ban ID",
             "note_multiple_bans": "Not: Tanımlayıcılarınız üzerinde birden fazla aktif yasağınız var.",
             "note_diff_license": "Note: the ban above was applied for another <code>license</code>, which means some of your IDs/HWIDs match the ones associated with that ban."
+        },
+        "embed": {
+            "title": "Player Banned",
+            "idban_description": "**Reason:** %{reason}\n**Expires:** %{expiration}\n\n**Identifiers:**\n```%{identifiers}```",
+            "playerban_description": "**Player:** %{player}\n**Reason:** %{reason}\n**Expires:** %{expiration}\n\n**Identifiers:**\n```%{identifiers}```"
         }
     },
     "whitelist_messages": {
@@ -362,6 +371,24 @@
                 "previous_ids": "Daha Önce Kullanılan Tanımlayıcılar",
                 "all_hwids": "All Hardware IDs"
             }
+        }
+    },
+    "warning_messages": {
+        "embed": {
+            "title": "Player Warned",
+            "description": "**Player:** %{player}\n**Reason:** %{reason}\n\n**Identifiers:**\n```%{identifiers}```"
+        }
+    },
+    "revocation_messages": {
+        "embed": {
+            "title": "Action Revoked",
+            "description": "**Action Type:** %{action} (`#%{actionId}`)\n**Target:** %{target}\n\n**Identifiers:**\n```%{identifiers}```"
+        }
+    },
+    "dm_messages": {
+        "embed": {
+            "title": "Admin DM Sent",
+            "description": "**Recipient:** %{player}\n**Message:**\n%{message}"
         }
     }
 }

--- a/locale/uk.json
+++ b/locale/uk.json
@@ -14,7 +14,11 @@
     "kick_messages": {
         "everyone": "Всіх гравців викинуто: %{reason}.",
         "player": "Ви були викинуті: %{reason}.",
-        "unknown_reason": "з невідомої причини"
+        "unknown_reason": "з невідомої причини",
+        "embed": {
+            "title": "Player Kicked",
+            "playerban_description": "**Player:** %{player}\n**Reason:** %{reason}\n\n**Identifiers:**\n```%{identifiers}```"
+        }
     },
     "ban_messages": {
         "kick_temporary": "(%{author}) Ви були забанені на цьому сервері за \"%{reason}\". Ваш бан закінчиться через: %{expiration}.",
@@ -29,6 +33,11 @@
             "label_id": "ID бана",
             "note_multiple_bans": "Примітка: у вас є кілька активних банів на ваших ідентифікаторах.",
             "note_diff_license": "Примітка: бан вище був застосований до іншої <code>license</code>, що означає, що деякі з ваших ID/HWID збігаються з тими, що асоціюються з цим баном."
+        },
+        "embed": {
+            "title": "Player Banned",
+            "idban_description": "**Reason:** %{reason}\n**Expires:** %{expiration}\n\n**Identifiers:**\n```%{identifiers}```",
+            "playerban_description": "**Player:** %{player}\n**Reason:** %{reason}\n**Expires:** %{expiration}\n\n**Identifiers:**\n```%{identifiers}```"
         }
     },
     "whitelist_messages": {
@@ -362,6 +371,24 @@
                 "helper_text": "Будь ласка, виберіть тривалість",
                 "submit": "Застосувати бан"
             }
+        }
+    },
+    "warning_messages": {
+        "embed": {
+            "title": "Player Warned",
+            "description": "**Player:** %{player}\n**Reason:** %{reason}\n\n**Identifiers:**\n```%{identifiers}```"
+        }
+    },
+    "revocation_messages": {
+        "embed": {
+            "title": "Action Revoked",
+            "description": "**Action Type:** %{action} (`#%{actionId}`)\n**Target:** %{target}\n\n**Identifiers:**\n```%{identifiers}```"
+        }
+    },
+    "dm_messages": {
+        "embed": {
+            "title": "Admin DM Sent",
+            "description": "**Recipient:** %{player}\n**Message:**\n%{message}"
         }
     }
 }

--- a/locale/vi.json
+++ b/locale/vi.json
@@ -14,7 +14,11 @@
     "kick_messages": {
         "everyone": "Tất cả người chơi đã bị kick: %{reason}.",
         "player": "Bạn đã bị kick: %{reason}.",
-        "unknown_reason": "không có lý do nào được đưa ra"
+        "unknown_reason": "không có lý do nào được đưa ra",
+        "embed": {
+            "title": "Player Kicked",
+            "playerban_description": "**Player:** %{player}\n**Reason:** %{reason}\n\n**Identifiers:**\n```%{identifiers}```"
+        }
     },
     "ban_messages": {
         "kick_temporary": "(%{author}) Bạn đã bị cấm tham gia máy chủ vì lý do: \"%{reason}\". Thời hạn cấm sẽ hết hạn sau: %{expiration}.",
@@ -29,6 +33,11 @@
             "label_id": "ID cấm",
             "note_multiple_bans": "Lưu ý: bạn có nhiều hơn một lệnh cấm hoạt động đối với tài khoản của mình.",
             "note_diff_license": "Lưu ý: lệnh cấm ở trên đã được áp dụng cho một <code>giấy phép</code> khác, có nghĩa là một số ID/HWID của bạn khớp với những ID/HWID được liên kết với lệnh cấm đó."
+        },
+        "embed": {
+            "title": "Player Banned",
+            "idban_description": "**Reason:** %{reason}\n**Expires:** %{expiration}\n\n**Identifiers:**\n```%{identifiers}```",
+            "playerban_description": "**Player:** %{player}\n**Reason:** %{reason}\n**Expires:** %{expiration}\n\n**Identifiers:**\n```%{identifiers}```"
         }
     },
     "whitelist_messages": {
@@ -362,6 +371,24 @@
                 "helper_text": "Vui lòng nhập thời gian cấm người chơi.",
                 "submit": "Xác nhận"
             }
+        }
+    },
+    "warning_messages": {
+        "embed": {
+            "title": "Player Warned",
+            "description": "**Player:** %{player}\n**Reason:** %{reason}\n\n**Identifiers:**\n```%{identifiers}```"
+        }
+    },
+    "revocation_messages": {
+        "embed": {
+            "title": "Action Revoked",
+            "description": "**Action Type:** %{action} (`#%{actionId}`)\n**Target:** %{target}\n\n**Identifiers:**\n```%{identifiers}```"
+        }
+    },
+    "dm_messages": {
+        "embed": {
+            "title": "Admin DM Sent",
+            "description": "**Recipient:** %{player}\n**Message:**\n%{message}"
         }
     }
 }

--- a/locale/zh.json
+++ b/locale/zh.json
@@ -14,7 +14,11 @@
     "kick_messages": {
         "everyone": "已踢出所有玩家。原因: %{reason}.",
         "player": "您已被踢出。原因: %{reason}.",
-        "unknown_reason": "未知原因"
+        "unknown_reason": "未知原因",
+        "embed": {
+            "title": "Player Kicked",
+            "playerban_description": "**Player:** %{player}\n**Reason:** %{reason}\n\n**Identifiers:**\n```%{identifiers}```"
+        }
     },
     "ban_messages": {
         "kick_temporary": "您因 \"%{reason}\" 而被封禁。您可在 %{expiration} 后再次登录服务器。操作人：%{author}",
@@ -29,6 +33,11 @@
             "label_id": "封禁ID",
             "note_multiple_bans": "提示：您还有其他激活的封禁。",
             "note_diff_license": "提示：上述封禁适用于另一个<code>license</code>，这意味着您的一些ID/HWID与该禁令相关的ID/HWID匹配。"
+        },
+        "embed": {
+            "title": "Player Banned",
+            "idban_description": "**Reason:** %{reason}\n**Expires:** %{expiration}\n\n**Identifiers:**\n```%{identifiers}```",
+            "playerban_description": "**Player:** %{player}\n**Reason:** %{reason}\n**Expires:** %{expiration}\n\n**Identifiers:**\n```%{identifiers}```"
         }
     },
     "whitelist_messages": {
@@ -362,6 +371,24 @@
                 "previous_ids": "曾使用过的标识符",
                 "all_hwids": "所有硬件ID(HWID)"
             }
+        }
+    },
+    "warning_messages": {
+        "embed": {
+            "title": "Player Warned",
+            "description": "**Player:** %{player}\n**Reason:** %{reason}\n\n**Identifiers:**\n```%{identifiers}```"
+        }
+    },
+    "revocation_messages": {
+        "embed": {
+            "title": "Action Revoked",
+            "description": "**Action Type:** %{action} (`#%{actionId}`)\n**Target:** %{target}\n\n**Identifiers:**\n```%{identifiers}```"
+        }
+    },
+    "dm_messages": {
+        "embed": {
+            "title": "Admin DM Sent",
+            "description": "**Recipient:** %{player}\n**Message:**\n%{message}"
         }
     }
 }

--- a/panel/src/pages/Settings/tabCards/discord.tsx
+++ b/panel/src/pages/Settings/tabCards/discord.tsx
@@ -26,7 +26,8 @@ export const pageConfigs = {
     botEnabled: getPageConfig('discordBot', 'enabled'),
     botToken: getPageConfig('discordBot', 'token'),
     discordGuild: getPageConfig('discordBot', 'guild'),
-    warningsChannel: getPageConfig('discordBot', 'warningsChannel'),
+    restartsChannel: getPageConfig('discordBot', 'restartsChannel'),
+    punishmentsChannel: getPageConfig('discordBot', 'punishmentsChannel'),
     embedJson: getPageConfig('discordBot', 'embedJson'),
     embedConfigJson: getPageConfig('discordBot', 'embedConfigJson'),
 } as const;
@@ -49,7 +50,8 @@ export default function ConfigCardDiscord({ cardCtx, pageCtx }: SettingsCardProp
     //Refs for configs that don't use state
     const botTokenRef = useRef<HTMLInputElement | null>(null);
     const discordGuildRef = useRef<HTMLInputElement | null>(null);
-    const warningsChannelRef = useRef<HTMLInputElement | null>(null);
+    const punishmentsChannelRef = useRef<HTMLInputElement | null>(null);
+    const restartsChannelRef = useRef<HTMLInputElement | null>(null);
 
     //Marshalling Utils
     const emptyToNull = (str?: string) => {
@@ -63,7 +65,8 @@ export default function ConfigCardDiscord({ cardCtx, pageCtx }: SettingsCardProp
         const overwrites = {
             botToken: emptyToNull(botTokenRef.current?.value),
             discordGuild: emptyToNull(discordGuildRef.current?.value),
-            warningsChannel: emptyToNull(warningsChannelRef.current?.value),
+            punishmentsChannel: emptyToNull(punishmentsChannelRef.current?.value),
+            restartsChannel: emptyToNull(restartsChannelRef.current?.value),
         };
 
         const res = getConfigDiff(cfg, states, overwrites, false);
@@ -144,17 +147,32 @@ export default function ConfigCardDiscord({ cardCtx, pageCtx }: SettingsCardProp
                     To get the Server ID, go to Discord's settings and <TxAnchor href="https://support.discordapp.com/hc/article_attachments/115002742731/mceclip0.png">enable developer mode</TxAnchor>, then right-click on the guild icon select "Copy ID".
                 </SettingItemDesc>
             </SettingItem>
-            <SettingItem label="Warnings Channel ID" htmlFor={cfg.warningsChannel.eid} showOptional>
+            <SettingItem label="Restarts Channel ID" htmlFor={cfg.restartsChannel.eid} showOptional>
                 <Input
-                    id={cfg.warningsChannel.eid}
-                    ref={warningsChannelRef}
-                    defaultValue={cfg.warningsChannel.initialValue}
+                    id={cfg.restartsChannel.eid}
+                    ref={restartsChannelRef}
+                    defaultValue={cfg.restartsChannel.initialValue}
                     onInput={updatePageState}
                     disabled={pageCtx.isReadOnly}
                     placeholder='000000000000000000'
                 />
                 <SettingItemDesc>
                     The ID of the channel to send Announcements (eg server restarts). <br />
+                    You can leave it blank to disable this feature. <br />
+                    To get the channel ID, go to Discord's settings and <TxAnchor href="https://support.discordapp.com/hc/article_attachments/115002742731/mceclip0.png">enable developer mode</TxAnchor>, then right-click on the channel name and select "Copy ID".
+                </SettingItemDesc>
+            </SettingItem>
+            <SettingItem label="Punishments Channel ID" htmlFor={cfg.punishmentsChannel.eid} showOptional>
+                <Input
+                    id={cfg.punishmentsChannel.eid}
+                    ref={punishmentsChannelRef}
+                    defaultValue={cfg.punishmentsChannel.initialValue}
+                    onInput={updatePageState}
+                    disabled={pageCtx.isReadOnly}
+                    placeholder='000000000000000000'
+                />
+                <SettingItemDesc>
+                    The ID of the channel to send Punishments (eg warns, kicks, bans). <br />
                     You can leave it blank to disable this feature. <br />
                     To get the channel ID, go to Discord's settings and <TxAnchor href="https://support.discordapp.com/hc/article_attachments/115002742731/mceclip0.png">enable developer mode</TxAnchor>, then right-click on the channel name and select "Copy ID".
                 </SettingItemDesc>

--- a/panel/src/pages/Settings/tabCards/discord.tsx
+++ b/panel/src/pages/Settings/tabCards/discord.tsx
@@ -26,7 +26,7 @@ export const pageConfigs = {
     botEnabled: getPageConfig('discordBot', 'enabled'),
     botToken: getPageConfig('discordBot', 'token'),
     discordGuild: getPageConfig('discordBot', 'guild'),
-    restartsChannel: getPageConfig('discordBot', 'restartsChannel'),
+    announcementsChannel: getPageConfig('discordBot', 'announcementsChannel'),
     punishmentsChannel: getPageConfig('discordBot', 'punishmentsChannel'),
     embedJson: getPageConfig('discordBot', 'embedJson'),
     embedConfigJson: getPageConfig('discordBot', 'embedConfigJson'),
@@ -66,7 +66,7 @@ export default function ConfigCardDiscord({ cardCtx, pageCtx }: SettingsCardProp
             botToken: emptyToNull(botTokenRef.current?.value),
             discordGuild: emptyToNull(discordGuildRef.current?.value),
             punishmentsChannel: emptyToNull(punishmentsChannelRef.current?.value),
-            restartsChannel: emptyToNull(restartsChannelRef.current?.value),
+            announcementsChannel: emptyToNull(restartsChannelRef.current?.value),
         };
 
         const res = getConfigDiff(cfg, states, overwrites, false);
@@ -147,11 +147,11 @@ export default function ConfigCardDiscord({ cardCtx, pageCtx }: SettingsCardProp
                     To get the Server ID, go to Discord's settings and <TxAnchor href="https://support.discordapp.com/hc/article_attachments/115002742731/mceclip0.png">enable developer mode</TxAnchor>, then right-click on the guild icon select "Copy ID".
                 </SettingItemDesc>
             </SettingItem>
-            <SettingItem label="Restarts Channel ID" htmlFor={cfg.restartsChannel.eid} showOptional>
+            <SettingItem label="Announcements Channel ID" htmlFor={cfg.announcementsChannel.eid} showOptional>
                 <Input
-                    id={cfg.restartsChannel.eid}
+                    id={cfg.announcementsChannel.eid}
                     ref={restartsChannelRef}
-                    defaultValue={cfg.restartsChannel.initialValue}
+                    defaultValue={cfg.announcementsChannel.initialValue}
                     onInput={updatePageState}
                     disabled={pageCtx.isReadOnly}
                     placeholder='000000000000000000'


### PR DESCRIPTION
## Issue

When setting up txAdmin for a project, I was initially confused by the scope of the warnings channel in the discord settings, I initially thought it was for forwarding all the punishment actions made against a player / identifier towards discord.

## What was changed

This PR addresses this minor issue I encountered, by changing the name of the settings field (and backend variables) and also adds a sendPunishment method to the discord bot. When an admin bans, warns, kicks, DMs or revokes an action, this is now logged in a specific channel configured by the server admins in the panel.

## Notes

I am however unsure if my implementation of the config migration `ConfigStore/schema/oldConfig` is appropriate.
Localizations have been rebased using `npm run locale:rebase`.

I didn't consider the renaming changes (warningsChannel -> announcementsChannel) as a breaking change, as it doesn't seem to break anything, I'll run a few tests to check migration from db schema prior of these changes to post changes to check if it was implemented properly and correctly migrates the warningsChannel value to announcementsChannel.

## Previews

<img width="478" height="553" alt="image" src="https://github.com/user-attachments/assets/03a8bc5a-0d65-4306-8bcb-72705c7910ae" />
<img width="922" height="314" alt="image" src="https://github.com/user-attachments/assets/2b55849c-6c7f-4423-8588-235f6583e32d" />

