### PR TITLE
feat: adding jail feature

### DIFF
--- a/core/lib/misc.ts
+++ b/core/lib/misc.ts
@@ -236,7 +236,7 @@ export const anyUndefined = (...args: any) => [...args].some((x) => (typeof x ==
 /**
  * Calculates expiration and duration from a ban duration string like "1 day"
  */
-export const calcExpirationFromDuration = (inputDuration: string) => {
+export const calcExpirationFromDuration = (inputDuration: string, allowMinutes = false) => {
     let expiration;
     let duration;
     if (inputDuration === 'permanent') {
@@ -248,7 +248,9 @@ export const calcExpirationFromDuration = (inputDuration: string) => {
             throw new Error(`The duration number must be at least 1.`);
         }
 
-        if (unit.startsWith('hour')) {
+        if (allowMinutes && unit.startsWith('minute')) {
+            duration = multiplier * 60;
+        } else if (unit.startsWith('hour')) {
             duration = multiplier * 3600;
         } else if (unit.startsWith('day')) {
             duration = multiplier * 86400;
@@ -257,12 +259,24 @@ export const calcExpirationFromDuration = (inputDuration: string) => {
         } else if (unit.startsWith('month')) {
             duration = multiplier * 2592000; //30 days
         } else {
-            throw new Error(`Invalid ban duration. Supported units: hours, days, weeks, months`);
+            throw new Error(`Invalid duration. Supported units: ${allowMinutes ? 'minutes, ' : ''}hours, days, weeks, months`);
         }
         expiration = now() + duration;
     }
 
     return { expiration, duration };
+};
+
+
+/**
+ * Parses a "x, y, z" coordinates string into an object, or throws if invalid
+ */
+export const parseCoordsString = (coords: string) => {
+    const parts = coords.split(',').map((p) => parseFloat(p.trim()));
+    if (parts.length !== 3 || parts.some((p) => !Number.isFinite(p))) {
+        throw new Error(`Invalid coordinates string, expected "x, y, z" format.`);
+    }
+    return { x: parts[0], y: parts[1], z: parts[2] };
 };
 
 

--- a/core/lib/player/jailUtils.ts
+++ b/core/lib/player/jailUtils.ts
@@ -1,0 +1,13 @@
+import { parseCoordsString } from '@lib/misc';
+
+/**
+ * Returns the jail enforcement environment (bucket + positions) from the config,
+ * used in the playerJailed event and the pendingJail initial data payloads.
+ */
+export const getJailEnvironment = () => {
+    return {
+        bucket: txConfig.gameFeatures.jailRoutingBucket,
+        posFivem: parseCoordsString(txConfig.gameFeatures.jailPosFivem),
+        posRedm: parseCoordsString(txConfig.gameFeatures.jailPosRedm),
+    };
+};

--- a/core/lib/player/playerClasses.ts
+++ b/core/lib/player/playerClasses.ts
@@ -1,6 +1,6 @@
 const modulename = 'Player';
 import cleanPlayerName from '@shared/cleanPlayerName';
-import { DatabaseActionWarnType, DatabasePlayerType, DatabaseWhitelistApprovalsType } from '@modules/Database/databaseTypes';
+import { DatabaseActionJailType, DatabaseActionWarnType, DatabasePlayerType, DatabaseWhitelistApprovalsType } from '@modules/Database/databaseTypes';
 import { cloneDeep, union } from 'lodash-es';
 import { now } from '@lib/misc';
 import { parsePlayerIds } from '@lib/player/idUtils';
@@ -148,6 +148,7 @@ export class ServerPlayer extends BasePlayer {
     readonly tsConnected: number = now();
     readonly isRegistered: boolean;
     readonly #minuteCronInterval?: ReturnType<typeof setInterval>;
+    #jailSession: null | { actionId: string, tsLastPersist: number } = null;
     // #offlineDbDataCacheTimeout?: ReturnType<typeof setTimeout>;
 
     constructor(
@@ -252,18 +253,50 @@ export class ServerPlayer extends BasePlayer {
         if (!this.dbData) throw new Error(`cannot send initial data for a player that has no dbData`);
 
         let oldestPendingWarn: undefined | DatabaseActionWarnType;
+        let oldestActiveJail: undefined | DatabaseActionJailType;
         const actionHistory = this.getHistory();
         for (const action of actionHistory) {
-            if (action.type !== 'warn' || action.revocation.timestamp !== null) continue;
-            if (!action.acked) {
+            if (action.revocation.timestamp !== null) continue;
+            if (action.type === 'warn' && !oldestPendingWarn && !action.acked) {
                 oldestPendingWarn = action;
-                break;
+            } else if (action.type === 'jail' && !oldestActiveJail && action.served < action.duration) {
+                oldestActiveJail = action;
             }
         }
 
-        if (oldestPendingWarn) {
-            this.#fxPlayerlist.dispatchInitialPlayerData(this.netid, oldestPendingWarn);
+        if (oldestPendingWarn || oldestActiveJail) {
+            if (oldestActiveJail) {
+                this.startJailSession(oldestActiveJail.id);
+            }
+            this.#fxPlayerlist.dispatchInitialPlayerData(this.netid, oldestPendingWarn, oldestActiveJail);
         }
+    }
+
+
+    /**
+     * Starts tracking online served time for a jail action.
+     */
+    startJailSession(actionId: string) {
+        this.#jailSession = { actionId, tsLastPersist: now() };
+    }
+
+    /**
+     * Stops tracking the jail session, optionally persisting the pending served time.
+     */
+    clearJailSession(opts: { persist: boolean }) {
+        if (!this.#jailSession) return;
+        if (opts.persist) {
+            try {
+                txCore.database.actions.addJailServedTime(
+                    this.#jailSession.actionId,
+                    now() - this.#jailSession.tsLastPersist,
+                );
+            } catch (error) {
+                console.verbose.warn(`Failed to persist jail served time for player ${this.displayName}:`);
+                console.verbose.dir(error);
+            }
+        }
+        this.#jailSession = null;
     }
 
     /**
@@ -331,6 +364,27 @@ export class ServerPlayer extends BasePlayer {
             console.warn(`Failed to update playtime for player ${this.displayName}:`);
             console.dir(error);
         }
+
+        //Flush jail served time
+        if (this.#jailSession) {
+            try {
+                const currTs = now();
+                const updatedJail = txCore.database.actions.addJailServedTime(
+                    this.#jailSession.actionId,
+                    currTs - this.#jailSession.tsLastPersist,
+                );
+                this.#jailSession.tsLastPersist = currTs;
+                if (updatedJail.served >= updatedJail.duration) {
+                    //Backstop only: the game server releases the player and reports completion itself
+                    this.#jailSession = null;
+                }
+            } catch (error) {
+                //Action might have been revoked or removed
+                console.verbose.warn(`Failed to update jail served time for player ${this.displayName}:`);
+                console.verbose.dir(error);
+                this.#jailSession = null;
+            }
+        }
     }
 
 
@@ -338,6 +392,7 @@ export class ServerPlayer extends BasePlayer {
      * Marks this player as disconnected, and clears minute cron
      */
     disconnect() {
+        this.clearJailSession({ persist: true });
         this.isConnected = false;
         // this.dbData = false;
         this.idsOnline = [];

--- a/core/modules/AdminStore/index.js
+++ b/core/modules/AdminStore/index.js
@@ -72,6 +72,7 @@ export default class AdminStore {
             'players.warn': 'Warn',
             'players.kick': 'Kick',
             'players.ban': 'Ban',
+            'players.jail': 'Jail / Timeout',
             'players.freeze': 'Freeze Players',
             'players.heal': 'Heal', //self, everyone, and the "heal" button in player modal
             'players.playermode': 'NoClip / God Mode', //self playermode, and also the player spectate option

--- a/core/modules/ConfigStore/schema/gameFeatures.ts
+++ b/core/modules/ConfigStore/schema/gameFeatures.ts
@@ -73,6 +73,29 @@ const hideDefaultScheduledRestartWarning = typeDefinedConfig({
     fixer: SYM_FIXER_DEFAULT,
 });
 
+const coordsRegex = /^-?\d+(\.\d+)?\s*,\s*-?\d+(\.\d+)?\s*,\s*-?\d+(\.\d+)?$/;
+
+const jailRoutingBucket = typeDefinedConfig({
+    name: 'Jail Routing Bucket',
+    default: 916,
+    validator: z.number().int().min(1).max(1023),
+    fixer: SYM_FIXER_DEFAULT,
+});
+
+const jailPosFivem = typeDefinedConfig({
+    name: 'Jail Position (FiveM)',
+    default: '459.28, -1001.85, 24.91', //Mission Row PD cell block
+    validator: z.string().regex(coordsRegex, 'must be in the "x, y, z" format'),
+    fixer: SYM_FIXER_DEFAULT,
+});
+
+const jailPosRedm = typeDefinedConfig({
+    name: 'Jail Position (RedM)',
+    default: '-276.0, 806.0, 119.38', //Valentine sheriff jail cell
+    validator: z.string().regex(coordsRegex, 'must be in the "x, y, z" format'),
+    fixer: SYM_FIXER_DEFAULT,
+});
+
 
 export default {
     menuEnabled,
@@ -85,4 +108,7 @@ export default {
     hideDefaultDirectMessage,
     hideDefaultWarning,
     hideDefaultScheduledRestartWarning,
+    jailRoutingBucket,
+    jailPosFivem,
+    jailPosRedm,
 } as const;

--- a/core/modules/Database/dao/actions.ts
+++ b/core/modules/Database/dao/actions.ts
@@ -1,6 +1,6 @@
 import { cloneDeep } from 'lodash-es';
 import { DbInstance, SavePriority } from "../instance";
-import { DatabaseActionBanType, DatabaseActionType, DatabaseActionWarnType } from "../databaseTypes";
+import { DatabaseActionBanType, DatabaseActionJailType, DatabaseActionType, DatabaseActionWarnType } from "../databaseTypes";
 import { genActionID } from "../dbUtils";
 import { now } from '@lib/misc';
 import consoleFactory from '@lib/console';
@@ -178,6 +178,109 @@ export default class ActionsDao {
             throw error;
         }
     }
+
+    /**
+     * Registers a jail action and returns its id
+     */
+    registerJail(
+        ids: string[],
+        author: string,
+        reason: string,
+        duration: number,
+        playerName: string | false = false,
+    ): string {
+        //Sanity check
+        if (!Array.isArray(ids) || !ids.length) throw new Error('Invalid ids array.');
+        if (typeof author !== 'string' || !author.length) throw new Error('Invalid author.');
+        if (typeof reason !== 'string' || !reason.length) throw new Error('Invalid reason.');
+        if (typeof duration !== 'number' || !Number.isFinite(duration) || duration <= 0) throw new Error('Invalid duration.');
+        if (playerName !== false && (typeof playerName !== 'string' || !playerName.length)) throw new Error('Invalid playerName.');
+
+        //Saves it to the database
+        const timestamp = now();
+        try {
+            const actionID = genActionID(this.dbo, 'jail');
+            const toDB: DatabaseActionJailType = {
+                id: actionID,
+                type: 'jail',
+                ids,
+                playerName,
+                reason,
+                author,
+                timestamp,
+                expiration: false,
+                duration: Math.round(duration),
+                served: 0,
+                revocation: {
+                    timestamp: null,
+                    author: null,
+                },
+            };
+            this.chain.get('actions')
+                .push(toDB)
+                .value();
+            this.db.writeFlag(SavePriority.HIGH);
+            return actionID;
+        } catch (error) {
+            let msg = `Failed to register jail to database with message: ${(error as Error).message}`;
+            console.error(msg);
+            console.verbose.dir(error);
+            throw error;
+        }
+    }
+
+
+    /**
+     * Adds served time to a jail action, clamped to its duration, and returns the updated action
+     */
+    addJailServedTime(actionId: string, seconds: number): DatabaseActionJailType {
+        if (typeof actionId !== 'string' || !actionId.length) throw new Error('Invalid actionId.');
+        if (typeof seconds !== 'number' || !Number.isFinite(seconds)) throw new Error('Invalid seconds.');
+
+        try {
+            const action = this.chain.get('actions')
+                .find({ id: actionId })
+                .value();
+            if (!action) throw new Error(`action not found`);
+            if (action.type !== 'jail') throw new Error(`action is not a jail`);
+            if (action.revocation.timestamp !== null) throw new Error(`action is revoked`);
+            action.served = Math.min(
+                action.duration,
+                action.served + Math.max(0, Math.round(seconds))
+            );
+            this.db.writeFlag(SavePriority.MEDIUM);
+            return cloneDeep(action);
+        } catch (error) {
+            const msg = `Failed to add jail served time with message: ${(error as Error).message}`;
+            console.error(msg);
+            console.verbose.dir(error);
+            throw error;
+        }
+    }
+
+
+    /**
+     * Marks a jail sentence as fully served
+     */
+    finishJailSentence(actionId: string) {
+        if (typeof actionId !== 'string' || !actionId.length) throw new Error('Invalid actionId.');
+
+        try {
+            const action = this.chain.get('actions')
+                .find({ id: actionId })
+                .value();
+            if (!action) throw new Error(`action not found`);
+            if (action.type !== 'jail') throw new Error(`action is not a jail`);
+            action.served = action.duration;
+            this.db.writeFlag(SavePriority.HIGH);
+        } catch (error) {
+            const msg = `Failed to finish jail sentence with message: ${(error as Error).message}`;
+            console.error(msg);
+            console.verbose.dir(error);
+            throw error;
+        }
+    }
+
 
     /**
      * Marks a warning as acknowledged

--- a/core/modules/Database/dao/stats.ts
+++ b/core/modules/Database/dao/stats.ts
@@ -58,6 +58,8 @@ export default class StatsDao {
             warnsLast7d: 0,
             totalBans: 0,
             bansLast7d: 0,
+            totalJails: 0,
+            jailsLast7d: 0,
             groupedByAdmins: new MultipleCounter(),
         };
         const actionStats = this.chain.get('actions')
@@ -68,6 +70,9 @@ export default class StatsDao {
                 } else if (action.type == 'warn') {
                     acc.totalWarns++;
                     if (action.timestamp > sevenDaysAgo) acc.warnsLast7d++;
+                } else if (action.type == 'jail') {
+                    acc.totalJails++;
+                    if (action.timestamp > sevenDaysAgo) acc.jailsLast7d++;
                 }
                 acc.groupedByAdmins.count(action.author);
                 return acc;
@@ -92,9 +97,11 @@ export default class StatsDao {
                     acc.bans++;
                 } else if (a.type == 'warn') {
                     acc.warns++;
+                } else if (a.type == 'jail') {
+                    acc.jails++;
                 }
                 return acc;
-            }, { bans: 0, warns: 0 })
+            }, { bans: 0, warns: 0, jails: 0 })
             .value();
 
         const playerStats = this.chain.get('players')

--- a/core/modules/Database/databaseTypes.ts
+++ b/core/modules/Database/databaseTypes.ts
@@ -39,7 +39,13 @@ export type DatabaseActionWarnType = {
     expiration: false; //FIXME: remove - BUT DO REMEMBER THE `'XXX' IN YYY` ISSUE!
     acked: boolean; //if the player has acknowledged the warning
 } & DatabaseActionBaseType;
-export type DatabaseActionType = DatabaseActionBanType | DatabaseActionWarnType;
+export type DatabaseActionJailType = {
+    type: 'jail';
+    expiration: false; //FIXME: remove - BUT DO REMEMBER THE `'XXX' IN YYY` ISSUE!
+    duration: number; //total sentence in seconds
+    served: number; //seconds served while online
+} & DatabaseActionBaseType;
+export type DatabaseActionType = DatabaseActionBanType | DatabaseActionWarnType | DatabaseActionJailType;
 
 export type DatabaseWhitelistApprovalsType = {
     identifier: string;

--- a/core/modules/DiscordBot/commands/info.ts
+++ b/core/modules/DiscordBot/commands/info.ts
@@ -105,13 +105,14 @@ export default async (interaction: CommandInteraction) => {
         if (includeAdminInfo) {
             //Counting bans/warns
             const actionHistory = player.getHistory();
-            const actionCount = { ban: 0, warn: 0 };
+            const actionCount = { ban: 0, warn: 0, jail: 0 };
             for (const log of actionHistory) {
                 actionCount[log.type]++;
             }
             const banText = (actionCount.ban === 1) ? '1 ban' : `${actionCount.ban} bans`;
             const warnText = (actionCount.warn === 1) ? '1 warn' : `${actionCount.warn} warns`;
-            bodyText['Log'] = `${banText}, ${warnText}`;
+            const jailText = (actionCount.jail === 1) ? '1 jail' : `${actionCount.jail} jails`;
+            bodyText['Log'] = `${banText}, ${warnText}, ${jailText}`;
 
             //Filling notes + identifiers
             const notesText = (dbData.notes) ? dbData.notes.text : 'nothing here';

--- a/core/modules/FxPlayerlist/index.ts
+++ b/core/modules/FxPlayerlist/index.ts
@@ -1,7 +1,8 @@
 const modulename = 'FxPlayerlist';
 import { cloneDeep } from 'lodash-es';
 import { ServerPlayer } from '@lib/player/playerClasses.js';
-import { DatabaseActionWarnType, DatabasePlayerType } from '@modules/Database/databaseTypes';
+import { DatabaseActionJailType, DatabaseActionWarnType, DatabasePlayerType } from '@modules/Database/databaseTypes';
+import { getJailEnvironment } from '@lib/player/jailUtils';
 import consoleFactory from '@lib/console';
 import { PlayerDroppedEventType, PlayerJoiningEventType } from '@shared/socketioTypes';
 import { SYM_SYSTEM_AUTHOR } from '@lib/symbols';
@@ -184,16 +185,39 @@ export default class FxPlayerlist {
     /**
      * Receives initial data callback from ServerPlayer and dispatches to the server as stdin.
      */
-    dispatchInitialPlayerData(playerId: number, pendingWarn: DatabaseActionWarnType) {
-        const cmdData = {
+    dispatchInitialPlayerData(
+        playerId: number,
+        pendingWarn?: DatabaseActionWarnType,
+        pendingJail?: DatabaseActionJailType,
+    ) {
+        const cmdData: any = {
             netId: playerId,
-            pendingWarn: {
+        };
+        if (pendingWarn) {
+            cmdData.pendingWarn = {
                 author: pendingWarn.author,
                 reason: pendingWarn.reason,
                 actionId: pendingWarn.id,
                 targetNetId: playerId,
                 targetIds: pendingWarn.ids, //not used in the playerWarned handler
                 targetName: pendingWarn.playerName,
+            };
+        }
+        if (pendingJail) {
+            try {
+                cmdData.pendingJail = {
+                    author: pendingJail.author,
+                    reason: pendingJail.reason,
+                    actionId: pendingJail.id,
+                    targetNetId: playerId,
+                    targetIds: pendingJail.ids,
+                    targetName: pendingJail.playerName,
+                    duration: pendingJail.duration,
+                    remaining: Math.max(1, pendingJail.duration - pendingJail.served),
+                    ...getJailEnvironment(),
+                };
+            } catch (error) {
+                console.error(`Failed to build pendingJail for player ${playerId}, the player will not be jailed on connect: ${(error as Error).message}`);
             }
         }
         txCore.fxRunner.sendCommand('txaInitialData', [cmdData], SYM_SYSTEM_AUTHOR);

--- a/core/modules/FxRunner/handleFd3Messages.ts
+++ b/core/modules/FxRunner/handleFd3Messages.ts
@@ -139,6 +139,11 @@ const handleFd3Messages = (mutex: string, trace: StructuredTraceType) => {
             handleBridgedCommands(data.payload);
         } else if (data.payload.type === 'txAdminAckWarning') {
             txCore.database.actions.ackWarn(data.payload.actionId);
+        } else if (data.payload.type === 'txAdminJailComplete') {
+            txCore.database.actions.finishJailSentence(data.payload.actionId);
+            if (typeof data.payload.netId === 'number') {
+                txCore.fxPlayerlist.getPlayerById(data.payload.netId)?.clearJailSession({ persist: false });
+            }
         }
     }
     

--- a/core/routes/history/actions.ts
+++ b/core/routes/history/actions.ts
@@ -157,6 +157,7 @@ async function handleRevokeAction(ctx: AuthedCtx): Promise<GenericApiOkResp> {
     const perms = [];
     if (ctx.admin.hasPermission('players.ban')) perms.push('ban');
     if (ctx.admin.hasPermission('players.warn')) perms.push('warn');
+    if (ctx.admin.hasPermission('players.jail')) perms.push('jail');
 
     let action;
     try {
@@ -164,6 +165,19 @@ async function handleRevokeAction(ctx: AuthedCtx): Promise<GenericApiOkResp> {
         ctx.admin.logAction(`Revoked ${action.type} id ${actionId} from ${action.playerName ?? 'identifiers'}`);
     } catch (error) {
         return { error: `Failed to revoke action: ${(error as Error).message}` };
+    }
+
+    //If a jail was revoked, stop tracking served time for any matching online player
+    if (action.type === 'jail') {
+        try {
+            const { idsFound } = txCore.fxPlayerlist.getAssociatedOnlineNetIds(action.ids);
+            const netids = new Set(idsFound.map(([, netid]) => netid));
+            for (const netid of netids) {
+                txCore.fxPlayerlist.getPlayerById(netid)?.clearJailSession({ persist: true });
+            }
+        } catch (error) {
+            console.verbose.error(`Failed to clear jail session on revoke: ${(error as Error).message}`);
+        }
     }
 
     // Dispatch `txAdmin:events:actionRevoked`

--- a/core/routes/history/search.ts
+++ b/core/routes/history/search.ts
@@ -134,7 +134,7 @@ export default async function HistorySearch(ctx: AuthedCtx) {
     const hasReachedEnd = actions.length <= DEFAULT_LIMIT;
     const currTs = now();
     const processedActions = actions.slice(0, DEFAULT_LIMIT).map((a) => {
-        let banExpiration, warnAcked;
+        let banExpiration, warnAcked, jailStatus;
         if (a.type === 'ban') {
             if (a.expiration === false) {
                 banExpiration = 'permanent' as const;
@@ -145,6 +145,8 @@ export default async function HistorySearch(ctx: AuthedCtx) {
             }
         } else if (a.type === 'warn') {
             warnAcked = a.acked;
+        } else if (a.type === 'jail') {
+            jailStatus = a.served >= a.duration ? 'served' as const : 'active' as const;
         }
         return {
             id: a.id,
@@ -156,6 +158,7 @@ export default async function HistorySearch(ctx: AuthedCtx) {
             isRevoked: !!a.revocation.timestamp,
             banExpiration,
             warnAcked,
+            jailStatus,
         } satisfies HistoryTableActionType;
     });
 

--- a/core/routes/player/actions.ts
+++ b/core/routes/player/actions.ts
@@ -3,6 +3,8 @@ import playerResolver from '@lib/player/playerResolver';
 import { GenericApiResp } from '@shared/genericApiTypes';
 import { PlayerClass, ServerPlayer } from '@lib/player/playerClasses';
 import { anyUndefined, calcExpirationFromDuration } from '@lib/misc';
+import { getJailEnvironment } from '@lib/player/jailUtils';
+import { DatabaseActionJailType } from '@modules/Database/databaseTypes';
 import consoleFactory from '@lib/console';
 import { AuthedCtx } from '@modules/WebServer/ctxTypes';
 import { SYM_CURRENT_MUTEX } from '@lib/symbols';
@@ -47,6 +49,8 @@ export default async function PlayerActions(ctx: AuthedCtx) {
         return sendTypedResp(await handleWarning(ctx, player));
     } else if (action === 'ban') {
         return sendTypedResp(await handleBan(ctx, player));
+    } else if (action === 'jail') {
+        return sendTypedResp(await handleJail(ctx, player));
     } else if (action === 'whitelist') {
         return sendTypedResp(await handleSetWhitelist(ctx, player));
     } else if (action === 'removeIds') {
@@ -236,6 +240,117 @@ async function handleBan(ctx: AuthedCtx, player: PlayerClass): Promise<GenericAp
         return { success: true };
     } else {
         return { error: `Player banned, but likely failed to kick player (stdin error).` };
+    }
+}
+
+
+/**
+ * Handle Jail (timeout) command
+ */
+async function handleJail(ctx: AuthedCtx, player: PlayerClass): Promise<GenericApiResp> {
+    //Checking request
+    if (
+        anyUndefined(
+            ctx.request.body,
+            ctx.request.body.duration,
+            ctx.request.body.reason,
+        )
+    ) {
+        return { error: 'Invalid request.' };
+    }
+    const durationInput = ctx.request.body.duration.trim();
+    const reason = (ctx.request.body.reason as string).trim() || 'no reason provided';
+
+    //Calculating duration - jails cannot be permanent
+    if (durationInput === 'permanent') {
+        return { error: 'Jails cannot be permanent, use a ban instead.' };
+    }
+    let duration;
+    try {
+        duration = calcExpirationFromDuration(durationInput, true).duration;
+        if (!duration) throw new Error('Invalid duration.');
+    } catch (error) {
+        return { error: (error as Error).message };
+    }
+
+    //Check permissions
+    if (!ctx.admin.testPermission('players.jail', modulename)) {
+        return { error: 'You don\'t have permission to execute this action.' }
+    }
+
+    //Validating player
+    const allIds = player.allIdentifiers;
+    if (!allIds.length) {
+        return { error: 'Cannot jail a player with no identifiers.' }
+    }
+
+    //Checking for an already active jail
+    const activeJails = txCore.database.actions.findMany(
+        allIds,
+        undefined,
+        (a): a is DatabaseActionJailType => a.type === 'jail'
+            && a.revocation.timestamp === null
+            && a.served < a.duration,
+    );
+    if (activeJails.length) {
+        return { error: `This player already has an active jail (ID ${activeJails[0].id}). Revoke it first or wait for it to end.` };
+    }
+
+    let jailEnvironment;
+    try {
+        jailEnvironment = getJailEnvironment();
+    } catch (error) {
+        return { error: `Invalid jail environment config: ${(error as Error).message}` };
+    }
+
+    //Register action
+    let actionId;
+    try {
+        actionId = txCore.database.actions.registerJail(
+            allIds,
+            ctx.admin.name,
+            reason,
+            duration,
+            player.displayName,
+        );
+    } catch (error) {
+        return { error: `Failed to jail player: ${(error as Error).message}` };
+    }
+    ctx.admin.logAction(`Jailed player "${player.displayName}" for ${durationInput}: ${reason}`);
+
+    //No need to dispatch events if server is not online
+    if (txCore.fxRunner.isIdle) {
+        return { success: true };
+    }
+
+    //If the player is connected, start tracking the served time
+    let targetNetId = null;
+    if (player instanceof ServerPlayer && player.isConnected) {
+        targetNetId = player.netid;
+        player.startJailSession(actionId);
+    }
+
+    // Dispatch `txAdmin:events:playerJailed`
+    const eventSent = txCore.fxRunner.sendEvent('playerJailed', {
+        author: ctx.admin.name,
+        reason,
+        actionId,
+        targetNetId,
+        targetIds: allIds,
+        targetName: player.displayName,
+        duration,
+        remaining: duration,
+        ...jailEnvironment,
+    });
+
+    if (eventSent) {
+        return { success: true };
+    } else {
+         if (player instanceof ServerPlayer && player.isConnected) {
+            targetNetId = player.netid;
+            player.clearJailSession({ persist: true });
+        }
+        return { error: `Jail saved, but likely failed to jail the player in game (stdin error).` };
     }
 }
 

--- a/core/routes/player/actions.ts
+++ b/core/routes/player/actions.ts
@@ -248,19 +248,12 @@ async function handleBan(ctx: AuthedCtx, player: PlayerClass): Promise<GenericAp
  * Handle Jail (timeout) command
  */
 async function handleJail(ctx: AuthedCtx, player: PlayerClass): Promise<GenericApiResp> {
-    //Checking request
-    if (
-        anyUndefined(
-            ctx.request.body,
-            ctx.request.body.duration,
-            ctx.request.body.reason,
-        )
-    ) {
+    const body = ctx.request.body;
+    if (!body || typeof body.duration !== 'string' || typeof body.reason !== 'string') {
         return { error: 'Invalid request.' };
     }
-    const durationInput = ctx.request.body.duration.trim();
-    const reason = (ctx.request.body.reason as string).trim() || 'no reason provided';
-
+    const durationInput = body.duration.trim();
+    const reason = body.reason.trim() || 'no reason provided';
     //Calculating duration - jails cannot be permanent
     if (durationInput === 'permanent') {
         return { error: 'Jails cannot be permanent, use a ban instead.' };

--- a/core/routes/player/modal.ts
+++ b/core/routes/player/modal.ts
@@ -21,6 +21,8 @@ const processHistoryLog = (hist: DatabaseActionType[]) => {
                 author: log.author,
                 ts: log.timestamp,
                 exp: log.expiration ? log.expiration : undefined,
+                duration: log.type === 'jail' ? log.duration : undefined,
+                served: log.type === 'jail' ? log.served : undefined,
                 revokedBy: log.revocation.author ? log.revocation.author : undefined,
                 revokedAt: log.revocation.timestamp ? log.revocation.timestamp : undefined,
             };

--- a/docs/events.md
+++ b/docs/events.md
@@ -91,6 +91,29 @@ Event Data:
 - `target`: The ID of the healed player, or `-1` if the entire server was healed.
 - `author`: The name of the admin that triggered the heal.
 
+### txAdmin:events:playerJailed
+Broadcasted when a player is jailed (timeout) using txAdmin, including when an active jail is re-applied after the player reconnects.  
+The jail time only counts while the player is online. Other resources (phone, jobs, etc.) can listen to this event to disable themselves for the jailed player. The jailed status is also available in the `txAdminJailed` player state bag.  
+Event Data:
+- `author`: The name of the admin.
+- `reason`: The reason of the jail.
+- `actionId`: The ID of this action.
+- `targetNetId`: The netid of the player that was jailed, or `null` if the target is not online.
+- `targetIds`: The identifiers that were jailed.
+- `targetName`: The clean name of the jailed player.
+- `duration`: The total jail sentence, in seconds.
+- `remaining`: The seconds left to serve (equals `duration` when the jail is first applied).
+- `bucket`: The routing bucket used to isolate the jailed player.
+- `posFivem`: The `{x, y, z}` jail coordinates for FiveM servers.
+- `posRedm`: The `{x, y, z}` jail coordinates for RedM servers.
+
+### txAdmin:events:playerJailReleased
+Broadcasted (server-side only) when a jailed player is released, either by fully serving the sentence or by an admin revoking the jail action.  
+Event Data:
+- `actionId`: The ID of the jail action.
+- `netId`: The netid of the released player.
+- `reason`: `completed` or `revoked`.
+
 ### txAdmin:events:playerKicked
 Broadcasted when a player is kicked using txAdmin.  
 Note: starting on v8.0, the `target` parameter might be `-1`, and `dropMessage` was introduced.

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -24,6 +24,7 @@ The permissions are saved in the `txData/admins.json` file and can be edited thr
 - `players.warn`: Warn a player.
 - `players.kick`: Kick a player.
 - `players.ban`: Ban/Unban a player.
+- `players.jail`: Jail (timeout) a player, or release them by revoking the jail action.
 - `players.freeze`: Freeze a player's ped.
 - `players.heal`: Heal self or everyone.
 - `players.playermode`: Toggle NoClip, God Mode, or Superjump.

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -30,6 +30,7 @@ server_scripts {
     'resource/sv_playerlist.lua',
     'resource/sv_ctx.lua',
     'resource/sv_initialData.lua',
+    'resource/sv_jail.lua',
     'resource/menu/server/sv_webpipe.lua',
     'resource/menu/server/sv_functions.lua',
     'resource/menu/server/sv_main_page.lua',
@@ -48,6 +49,7 @@ client_scripts {
     'resource/menu/client/cl_webpipe.lua',
     'resource/menu/client/cl_base.lua',
     'resource/menu/client/cl_functions.lua',
+    'resource/cl_jail.lua', --after cl_functions for the alert helpers
     'resource/menu/client/cl_instructional_ui.lua',
     'resource/menu/client/cl_main_page.lua',
     'resource/menu/client/cl_vehicle.lua',

--- a/locale/de.json
+++ b/locale/de.json
@@ -72,6 +72,13 @@
         "dismiss_key": "LEERTASTE",
         "instruction": "Halte deine %{key} für %{smart_count} Sekunde gedrückt, um diese Mitteilung zu schließen. |||| Halte deine %{key} für %{smart_count} Sekunden gedrückt, um diese Mitteilung zu schließen."
     },
+    "nui_jail": {
+        "title": "JAILED",
+        "reason_label": "Reason:",
+        "jailed_by": "Jailed by:",
+        "remaining_label": "Time remaining:",
+        "instruction": "You cannot move while being jailed. This screen will close automatically once your sentence ends."
+    },
     "nui_menu": {
         "misc": {
             "help_message": "txAdmin Menü aktiviert, tippe /tx ein, um es zu öffnen.\nDu kannst zusätzlich in den Einstellungen eine Taste zuweisen [Einstellungen > Steuerung > FiveM > txAdmin].",
@@ -89,6 +96,10 @@
             "froze_player": "Du hast den Spieler eingefroren.",
             "unfroze_player": "Du hast den Spieler aufgetaut.",
             "was_frozen": "Du wurdest von einem Teammitglied eingefroren!"
+        },
+        "jail": {
+            "jailed_alert": "Du wurdest von %{author} für: %{reason} gejailt. (Zeit übrig: %{time})",
+            "released": "Du wurdest aus dem Jail entlassen."
         },
         "common": {
             "cancel": "Abbrechen",
@@ -254,6 +265,7 @@
                 "info": "Info",
                 "ids": "IDs",
                 "history": "Vergangenheit",
+                "jail": "Jail",
                 "ban": "Ban"
             },
             "actions": {
@@ -325,9 +337,10 @@
                 "btn_wl_remove": "WL ENTFERNEN",
                 "btn_wl_success": "Whitelist-Status geändert",
                 "log_label": "Log",
-                "log_empty": "Keine Banns/Verwarnungen gefunden.",
+                "log_empty": "Keine Banns/Verwarnungen/Jails gefunden.",
                 "log_ban_count": "%{smart_count} Bann |||| %{smart_count} Banns",
                 "log_warn_count": "%{smart_count} Verwarnung |||| %{smart_count} Verwarnungen",
+                "log_jail_count": "%{smart_count} Jail |||| %{smart_count} Jails",
                 "log_btn": "DETAILS",
                 "notes_changed": "Notizen geändert",
                 "notes_placeholder": "Notizen über diesen Spieler..."
@@ -338,9 +351,18 @@
                 "revoked_success": "Aktion rückgängig gemacht!",
                 "banned_by": "GEBANNT von %{author}",
                 "warned_by": "VERWARNT von %{author}",
+                "jailed_by": "GEJAILT von %{author}",
                 "revoked_by": "RÜCKGÄNGIG GEMACHT von %{author}.",
                 "expired_at": "Abgelaufen am %{date}.",
                 "expires_at": "Läuft ab am %{date}."
+            },
+            "jail": {
+                "title": "Jail player",
+                "reason_required": "The Reason field is required.",
+                "success": "Player jailed!",
+                "minutes": "minutes",
+                "helper_text": "Please select a duration - only counts while the player is online",
+                "submit": "Apply jail"
             },
             "ban": {
                 "title": "Spieler bannen",

--- a/locale/en.json
+++ b/locale/en.json
@@ -72,6 +72,13 @@
         "dismiss_key": "SPACE",
         "instruction": "Hold %{key} for %{smart_count} second to dismiss this message. |||| Hold %{key} for %{smart_count} seconds to dismiss this message. "
     },
+    "nui_jail": {
+        "title": "JAILED",
+        "reason_label": "Reason:",
+        "jailed_by": "Jailed by:",
+        "remaining_label": "Time remaining:",
+        "instruction": "You cannot move while jailed. This screen will close automatically once your sentence ends."
+    },
     "nui_menu": {
         "misc": {
             "help_message": "txAdmin Menu enabled, type /tx to open it.\nYou can also configure a keybind at [Game Settings > Key Bindings > FiveM > Menu: Open Main Page].",
@@ -89,6 +96,10 @@
             "froze_player": "You have frozen the player!",
             "unfroze_player": "You have unfrozen the player!",
             "was_frozen": "You have been frozen by a server admin!"
+        },
+        "jail": {
+            "jailed_alert": "You have been jailed by %{author} for: %{reason} (%{time} remaining)",
+            "released": "You have been released from jail!"
         },
         "common": {
             "cancel": "Cancel",
@@ -254,6 +265,7 @@
                 "info": "Info",
                 "ids": "IDs",
                 "history": "History",
+                "jail": "Jail",
                 "ban": "Ban"
             },
             "actions": {
@@ -343,9 +355,18 @@
                 "revoked_success": "Action revoked!",
                 "banned_by": "BANNED by %{author}",
                 "warned_by": "WARNED by %{author}",
+                "jailed_by": "JAILED by %{author}",
                 "revoked_by": "Revoked by %{author}.",
                 "expired_at": "Expired at %{date}.",
                 "expires_at": "Expires at %{date}."
+            },
+            "jail": {
+                "title": "Jail player",
+                "reason_required": "The Reason field is required.",
+                "success": "Player jailed!",
+                "minutes": "minutes",
+                "helper_text": "Please select a duration - only counts while the player is online",
+                "submit": "Apply jail"
             },
             "ban": {
                 "title": "Ban player",

--- a/nui/src/MenuWrapper.tsx
+++ b/nui/src/MenuWrapper.tsx
@@ -10,6 +10,7 @@ import { debugData } from "./utils/debugData";
 import { I18n } from "react-polyglot";
 import { useServerCtxValue } from "./state/server.state";
 import { WarnPage } from "./components/WarnPage/WarnPage";
+import { JailPage } from "./components/JailPage/JailPage";
 import { IFrameProvider } from "./provider/IFrameProvider";
 import { PlayerModalProvider } from "./provider/PlayerModalProvider";
 import { txAdminMenuPage, useSetPage } from "./state/page.state";
@@ -107,6 +108,7 @@ const MenuWrapper: React.FC = () => {
             </DialogProvider>
           </IFrameProvider>
           <WarnPage />
+          <JailPage />
         </>
       </I18n>
     </TopLevelErrorBoundary>

--- a/nui/src/components/JailPage/JailPage.tsx
+++ b/nui/src/components/JailPage/JailPage.tsx
@@ -1,0 +1,180 @@
+import React, { useEffect, useState } from "react";
+import { styled } from '@mui/material/styles';
+import { Box, Fade, Typography } from "@mui/material";
+import { useNuiEvent } from "../../hooks/useNuiEvent";
+import { useTranslate } from "react-polyglot";
+import { debugData } from "../../utils/debugData";
+import { LockOutlined } from "@mui/icons-material";
+
+
+/**
+ * Jail box
+ */
+const boxClasses = {
+  root: `JailBox-root`,
+  inner: `JailBox-inner`,
+  title: `JailBox-title`,
+  row: `JailBox-row`,
+  label: `JailBox-label`,
+  instruction: `JailBox-instruction`
+};
+
+const JailInnerStyles = styled('div')({
+  color: "whitesmoke",
+  maxWidth: "700px",
+
+  [`& .${boxClasses.inner}`]: {
+    padding: 32,
+    border: "3px dashed whitesmoke",
+    borderRadius: 12,
+  },
+  [`& .${boxClasses.title}`]: {
+    display: "flex",
+    margin: "-20px auto 18px auto",
+    width: "max-content",
+    borderBottom: "2px solid whitesmoke",
+    paddingBottom: 5,
+    fontWeight: 700,
+  },
+  [`& .${boxClasses.row}`]: {
+    display: "flex",
+    justifyContent: "space-between",
+    gap: 16,
+    fontSize: "1.15em",
+    marginTop: 10,
+  },
+  [`& .${boxClasses.label}`]: {
+    opacity: 0.8,
+  },
+  [`& .${boxClasses.instruction}`]: {
+    marginTop: "1.5em",
+    textAlign: "center",
+    opacity: 0.85,
+  },
+});
+
+const JailIcon = () => (
+  <LockOutlined
+    style={{
+      color: "whitesmoke",
+      padding: "0 4px 0 4px",
+      height: "3rem",
+      width: "3rem",
+    }}
+  />
+);
+
+const formatRemaining = (totalSeconds: number) => {
+  const clamped = Math.max(0, totalSeconds);
+  const hours = Math.floor(clamped / 3600);
+  const mins = Math.floor((clamped % 3600) / 60);
+  const secs = clamped % 60;
+  const pad = (n: number) => n.toString().padStart(2, "0");
+  return hours > 0
+    ? `${pad(hours)}:${pad(mins)}:${pad(secs)}`
+    : `${pad(mins)}:${pad(secs)}`;
+};
+
+/**
+ * Main jail container (whole page)
+ */
+const mainClasses = {
+  root: `MainJail-root`,
+}
+
+const MainPageStyles = styled('div')(({
+  [`& .${mainClasses.root}`]: {
+    top: 0,
+    left: 0,
+    position: "absolute",
+    height: "100vh",
+    width: "100vw",
+    display: "flex",
+    flexDirection: "column",
+    gap: "1em",
+    justifyContent: "center",
+    alignItems: "center",
+    backgroundColor: "rgba(20, 20, 24, 0.92)",
+  },
+}));
+
+export interface SetJailOpenData {
+  author: string;
+  reason: string;
+  remainingSeconds: number;
+}
+
+export const JailPage: React.FC = ({ }) => {
+  const t = useTranslate();
+  const [isOpen, setIsOpen] = useState(false);
+  const [jailData, setJailData] = useState<SetJailOpenData | null>(null);
+  const [secsRemaining, setSecsRemaining] = useState(0);
+
+  useNuiEvent<SetJailOpenData>("setJailOpen", (jailData) => {
+    setJailData(jailData);
+    setSecsRemaining(jailData.remainingSeconds);
+    setIsOpen(true);
+  });
+
+  useNuiEvent("closeJail", () => {
+    setIsOpen(false);
+  });
+
+  //Ticks the countdown down locally between server resyncs
+  useEffect(() => {
+    if (!isOpen) return;
+    const tickTimer = setInterval(() => {
+      setSecsRemaining((prev) => Math.max(0, prev - 1));
+    }, 1000);
+    return () => clearInterval(tickTimer);
+  }, [isOpen]);
+
+  return (
+    <MainPageStyles>
+      <Fade in={isOpen}>
+        <Box className={mainClasses.root}>
+          <JailInnerStyles className={boxClasses.root}>
+            <Box className={boxClasses.inner}>
+              <Box className={boxClasses.title}>
+                <JailIcon />
+                <Typography variant="h3" style={{ fontWeight: 700 }}>
+                  {t("nui_jail.title")}
+                </Typography>
+                <JailIcon />
+              </Box>
+              <Box className={boxClasses.row}>
+                <span className={boxClasses.label}>{t("nui_jail.jailed_by")}</span>
+                <span>{jailData?.author ?? ''}</span>
+              </Box>
+              <Box className={boxClasses.row}>
+                <span className={boxClasses.label}>{t("nui_jail.reason_label")}</span>
+                <span>{jailData?.reason ?? ''}</span>
+              </Box>
+              <Box className={boxClasses.row}>
+                <span className={boxClasses.label}>{t("nui_jail.remaining_label")}</span>
+                <span>{formatRemaining(secsRemaining)}</span>
+              </Box>
+            </Box>
+            <Box className={boxClasses.instruction} fontWeight={600} letterSpacing={1}>
+              {t("nui_jail.instruction")}
+            </Box>
+          </JailInnerStyles>
+        </Box>
+      </Fade>
+    </MainPageStyles>
+  );
+};
+
+/**
+ * Browser mock
+ */
+// debugData([
+//   {
+//     action: 'setJailOpen',
+//     data: {
+//       author: 'Tabby',
+//       reason: 'Being bad',
+//       remainingSeconds: 125,
+//     }
+//   }
+// ], 500)

--- a/nui/src/components/PlayerModal/PlayerModal.tsx
+++ b/nui/src/components/PlayerModal/PlayerModal.tsx
@@ -14,6 +14,7 @@ import {
   Close,
   FlashOn,
   FormatListBulleted,
+  HourglassBottom,
   MenuBook,
   Person,
 } from "@mui/icons-material";
@@ -199,6 +200,13 @@ const DialogList: React.FC = () => {
         tab={PlayerModalTabs.HISTORY}
         curTab={curTab}
         icon={<MenuBook />}
+      />
+      <DialogTab
+        title={t("nui_menu.player_modal.tabs.jail")}
+        tab={PlayerModalTabs.JAIL}
+        curTab={curTab}
+        icon={<HourglassBottom />}
+        isDisabled={!userHasPerm("players.jail", playerPerms)}
       />
       <DialogTab
         title={t("nui_menu.player_modal.tabs.ban")}

--- a/nui/src/components/PlayerModal/Tabs/DialogBaseView.tsx
+++ b/nui/src/components/PlayerModal/Tabs/DialogBaseView.tsx
@@ -4,6 +4,7 @@ import DialogInfoView from "./DialogInfoView";
 import DialogIdView from "./DialogIdView";
 import DialogHistoryView from "./DialogHistoryView";
 import DialogBanView from "./DialogBanView";
+import DialogJailView from "./DialogJailView";
 import {Box} from "@mui/material";
 import {PlayerModalTabs, usePlayerModalTabValue} from "@nui/src/state/playerModal.state";
 
@@ -17,6 +18,8 @@ const tabToRender = (tab: PlayerModalTabs) => {
       return <DialogIdView />
     case PlayerModalTabs.HISTORY:
       return <DialogHistoryView />
+    case PlayerModalTabs.JAIL:
+      return <DialogJailView />
     case PlayerModalTabs.BAN:
       return <DialogBanView />
   }

--- a/nui/src/components/PlayerModal/Tabs/DialogHistoryView.tsx
+++ b/nui/src/components/PlayerModal/Tabs/DialogHistoryView.tsx
@@ -33,6 +33,7 @@ type ActionCardProps = {
   action: PlayerHistoryItem;
   permsDisableWarn: boolean;
   permsDisableBan: boolean;
+  permsDisableJail: boolean;
   serverTime: number;
   btnAction: Function;
 };
@@ -40,6 +41,7 @@ const ActionCard: React.FC<ActionCardProps> = ({
   action,
   permsDisableWarn,
   permsDisableBan,
+  permsDisableJail,
   serverTime,
   btnAction,
 }) => {
@@ -49,12 +51,18 @@ const ActionCard: React.FC<ActionCardProps> = ({
   const revokeButonDisabled =
     action.revokedBy !== undefined ||
     (action.type == "warn" && permsDisableWarn) ||
-    (action.type == "ban" && permsDisableBan);
+    (action.type == "ban" && permsDisableBan) ||
+    (action.type == "jail" && permsDisableJail);
 
   let footerNote, actionColor, actionMessage;
   if (action.type == "ban") {
     actionColor = colors.danger;
     actionMessage = t("nui_menu.player_modal.history.banned_by", {
+      author: action.author,
+    });
+  } else if (action.type == "jail") {
+    actionColor = colors.danger;
+    actionMessage = t("nui_menu.player_modal.history.jailed_by", {
       author: action.author,
     });
   } else if (action.type == "warn") {
@@ -171,6 +179,7 @@ const DialogHistoryView: React.FC = () => {
 
   const hasWarnPerm = userHasPerm('players.warn', userPerms);
   const hasBanPerm = userHasPerm('players.ban', userPerms);
+  const hasJailPerm = userHasPerm('players.jail', userPerms);
 
   return (
     <Box p={2} height="100%" display="flex" flexDirection="column">
@@ -187,6 +196,7 @@ const DialogHistoryView: React.FC = () => {
               action={action}
               permsDisableWarn={!hasWarnPerm}
               permsDisableBan={!hasBanPerm}
+              permsDisableJail={!hasJailPerm}
               serverTime={playerDetails.serverTime}
               btnAction={() => {
                 handleRevoke(action.id);

--- a/nui/src/components/PlayerModal/Tabs/DialogInfoView.tsx
+++ b/nui/src/components/PlayerModal/Tabs/DialogInfoView.tsx
@@ -105,7 +105,7 @@ const DialogInfoView: React.FC = () => {
   };
 
   //Log stuff
-  const counts = { ban: 0, warn: 0 };
+  const counts = { ban: 0, warn: 0, jail: 0 };
   for (const action of player.actionHistory) {
     counts[action.type]++;
   }
@@ -170,6 +170,12 @@ const DialogInfoView: React.FC = () => {
               <span style={{ color: theme.palette.warning.main }}>
                 {t("nui_menu.player_modal.info.log_warn_count", {
                   smart_count: counts.warn,
+                })}
+              </span>
+              ,&nbsp;
+              <span style={{ color: theme.palette.info.main }}>
+                {t("nui_menu.player_modal.info.log_jail_count", {
+                  smart_count: counts.jail,
                 })}
               </span>
             </>

--- a/nui/src/components/PlayerModal/Tabs/DialogJailView.tsx
+++ b/nui/src/components/PlayerModal/Tabs/DialogJailView.tsx
@@ -1,0 +1,192 @@
+import React, { useState } from "react";
+import {
+  Box,
+  Button,
+  DialogContent,
+  MenuItem,
+  TextField,
+  Typography,
+} from "@mui/material";
+import { useAssociatedPlayerValue } from "../../../state/playerDetails.state";
+import { fetchWebPipe } from "../../../utils/fetchWebPipe";
+import { useSnackbar } from "notistack";
+import { useTranslate } from "react-polyglot";
+import { usePlayerModalContext } from "../../../provider/PlayerModalProvider";
+import { userHasPerm } from "../../../utils/miscUtils";
+import { usePermissionsValue } from "../../../state/permissions.state";
+import { DialogLoadError } from "./DialogLoadError";
+import { GenericApiErrorResp, GenericApiResp } from "@shared/genericApiTypes";
+import { useSetPlayerModalVisibility } from "@nui/src/state/playerModal.state";
+
+const DialogJailView: React.FC = () => {
+  const assocPlayer = useAssociatedPlayerValue();
+  const [reason, setReason] = useState("");
+  const [duration, setDuration] = useState("30 minutes");
+  const [customDuration, setCustomDuration] = useState("minutes");
+  const [customDurLength, setCustomDurLength] = useState("1");
+  const t = useTranslate();
+  const setModalOpen = useSetPlayerModalVisibility();
+  const { enqueueSnackbar } = useSnackbar();
+  const { showNoPerms } = usePlayerModalContext();
+  const playerPerms = usePermissionsValue();
+
+  if (typeof assocPlayer !== "object") {
+    return <DialogLoadError />;
+  }
+
+  const handleJail = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!userHasPerm("players.jail", playerPerms)) return showNoPerms("Jail");
+
+    const trimmedReason = reason.trim();
+    if (!trimmedReason.length) {
+      enqueueSnackbar(t("nui_menu.player_modal.jail.reason_required"), {
+        variant: "error",
+      });
+      return;
+    }
+
+    const actualDuration = duration === "custom"
+      ? `${customDurLength} ${customDuration}`
+      : duration;
+
+    fetchWebPipe<GenericApiResp>(
+      `/player/jail?mutex=current&netid=${assocPlayer.id}`,
+      {
+        method: "POST",
+        data: {
+          reason: trimmedReason,
+          duration: actualDuration,
+        },
+      }
+    )
+      .then((result) => {
+        if ("success" in result && result.success) {
+          setModalOpen(false);
+          enqueueSnackbar(t(`nui_menu.player_modal.jail.success`), {
+            variant: "success",
+          });
+        } else {
+          enqueueSnackbar(
+            (result as GenericApiErrorResp).error ?? t("nui_menu.misc.unknown_error"),
+            { variant: "error" }
+          );
+        }
+      })
+      .catch((error) => {
+        enqueueSnackbar((error as Error).message, { variant: "error" });
+      });
+  };
+
+  const jailDurations = [
+    {
+      value: "15 minutes",
+      label: `15 ${t("nui_menu.player_modal.jail.minutes")}`,
+    },
+    {
+      value: "30 minutes",
+      label: `30 ${t("nui_menu.player_modal.jail.minutes")}`,
+    },
+    {
+      value: "1 hours",
+      label: `1 ${t("nui_menu.player_modal.ban.hours")}`,
+    },
+    {
+      value: "2 hours",
+      label: `2 ${t("nui_menu.player_modal.ban.hours")}`,
+    },
+    {
+      value: "custom",
+      label: t("nui_menu.player_modal.ban.custom"),
+    },
+  ];
+
+  const customJailLength = [
+    {
+      value: "minutes",
+      label: t("nui_menu.player_modal.jail.minutes"),
+    },
+    {
+      value: "hours",
+      label: t("nui_menu.player_modal.ban.hours"),
+    },
+    {
+      value: "days",
+      label: t("nui_menu.player_modal.ban.days"),
+    },
+  ];
+
+  return (
+    <DialogContent>
+      <Typography variant="h6" sx={{ mb: 2 }}>
+        {t("nui_menu.player_modal.jail.title")}
+      </Typography>
+      <form onSubmit={handleJail}>
+        <TextField
+          id="jail-reason"
+          autoFocus
+          size="small"
+          fullWidth
+          label="Reason"
+          value={reason}
+          onChange={(e) => setReason(e.target.value)}
+        />
+        <TextField
+          size="small"
+          select
+          required
+          sx={{ mt: 2 }}
+          label={t("nui_menu.player_modal.ban.duration_placeholder")}
+          variant="outlined"
+          value={duration}
+          onChange={(e) => setDuration(e.target.value)}
+          helperText={t("nui_menu.player_modal.jail.helper_text")}
+          fullWidth
+        >
+          {jailDurations.map((option) => (
+            <MenuItem key={option.value} value={option.value}>
+              {option.label}
+            </MenuItem>
+          ))}
+        </TextField>
+        {duration === "custom" && (
+          <Box display="flex" alignItems="stretch" gap={1}>
+            <TextField
+              type="number"
+              placeholder="1"
+              variant="outlined"
+              size="small"
+              value={customDurLength}
+              onChange={(e) => setCustomDurLength(e.target.value)}
+            />
+            <TextField
+              select
+              variant="outlined"
+              size="small"
+              fullWidth
+              value={customDuration}
+              onChange={(e) => setCustomDuration(e.target.value)}
+            >
+              {customJailLength.map((option) => (
+                <MenuItem key={option.value} value={option.value}>
+                  {option.label}
+                </MenuItem>
+              ))}
+            </TextField>
+          </Box>
+        )}
+        <Button
+          variant="contained"
+          type="submit"
+          color="warning"
+          sx={{ mt: 2 }}
+          onClick={handleJail}
+        >
+          {t("nui_menu.player_modal.jail.submit")}
+        </Button>
+      </form>
+    </DialogContent>
+  );
+};
+
+export default DialogJailView;

--- a/nui/src/hooks/useHudListenersService.tsx
+++ b/nui/src/hooks/useHudListenersService.tsx
@@ -113,10 +113,10 @@ export const useHudListenersService = () => {
 
   useNuiEvent<SnackbarPersistentAlert>(
     "setPersistentAlert",
-    ({ level, message, key, isTranslationKey }) => {
+    ({ level, message, key, isTranslationKey, tOptions }) => {
       if (alertMap.has(key)) return;
       const snackbarItem = enqueueSnackbar(
-        isTranslationKey ? t(message) : message,
+        isTranslationKey ? t(message, tOptions) : message,
         {
           variant: level,
           persist: true,

--- a/nui/src/state/permissions.state.ts
+++ b/nui/src/state/permissions.state.ts
@@ -10,6 +10,7 @@ export type ResolvablePermission =
   | "players.teleport"
   | "players.heal"
   | "players.ban"
+  | "players.jail"
   | "players.kick"
   | "players.direct_message"
   | "players.warn"

--- a/nui/src/state/playerModal.state.ts
+++ b/nui/src/state/playerModal.state.ts
@@ -10,6 +10,7 @@ export enum PlayerModalTabs {
   INFO,
   IDENTIFIERS,
   HISTORY,
+  JAIL,
   BAN,
 }
 

--- a/panel/src/components/JailForm.tsx
+++ b/panel/src/components/JailForm.tsx
@@ -31,12 +31,13 @@ export default forwardRef(function JailForm({ disabled }: JailFormProps, ref) {
     useImperativeHandle(ref, () => {
         return {
             getData: () => {
-                return {
-                    reason: reasonRef.current?.value.trim(),
-                    duration: currentDuration === 'custom'
-                        ? `${customMultiplierRef.current?.value} ${customUnits}`
-                        : currentDuration,
-                };
+                const reason = reasonRef.current?.value?.trim() ?? '';
+                let duration = currentDuration;
+                if (currentDuration === 'custom') {
+                    const mult = parseInt(customMultiplierRef.current?.value ?? '', 10);
+                    duration = Number.isFinite(mult) && mult > 0 ? `${mult} ${customUnits}` : `1 ${customUnits}`;
+                }
+                return { reason, duration };
             },
             clearData: () => {
                 if (!reasonRef.current || !customMultiplierRef.current) return;

--- a/panel/src/components/JailForm.tsx
+++ b/panel/src/components/JailForm.tsx
@@ -1,0 +1,125 @@
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { forwardRef, useImperativeHandle, useRef, useState } from "react";
+
+// Types
+type JailFormRespType = {
+    reason: string;
+    duration: string;
+}
+export type JailFormType = HTMLDivElement & {
+    focusReason: () => void;
+    clearData: () => void;
+    getData: () => JailFormRespType;
+}
+type JailFormProps = {
+    disabled?: boolean;
+};
+
+/**
+ * A form to set jail reason and duration.
+ * NOTE: jails cannot be permanent, and the time only counts while the player is online.
+ */
+export default forwardRef(function JailForm({ disabled }: JailFormProps, ref) {
+    const reasonRef = useRef<HTMLInputElement>(null);
+    const customMultiplierRef = useRef<HTMLInputElement>(null);
+    const [currentDuration, setCurrentDuration] = useState('30 minutes');
+    const [customUnits, setCustomUnits] = useState('minutes');
+
+    //Exposing methods to the parent
+    useImperativeHandle(ref, () => {
+        return {
+            getData: () => {
+                return {
+                    reason: reasonRef.current?.value.trim(),
+                    duration: currentDuration === 'custom'
+                        ? `${customMultiplierRef.current?.value} ${customUnits}`
+                        : currentDuration,
+                };
+            },
+            clearData: () => {
+                if (!reasonRef.current || !customMultiplierRef.current) return;
+                reasonRef.current.value = '';
+                customMultiplierRef.current.value = '';
+                setCurrentDuration('30 minutes');
+                setCustomUnits('minutes');
+            },
+            focusReason: () => {
+                reasonRef.current?.focus();
+            }
+        };
+    }, [reasonRef, customMultiplierRef, currentDuration, customUnits]);
+
+    return (
+        <div className="flex flex-col gap-4">
+            <div className="flex flex-col gap-3">
+                <Label htmlFor="jailReason">
+                    Reason
+                </Label>
+                <Input
+                    id="jailReason"
+                    ref={reasonRef}
+                    placeholder="The reason for the jail, rule violated, etc."
+                    className="w-full"
+                    disabled={disabled}
+                    autoFocus
+                />
+            </div>
+            <div className="flex flex-col gap-3">
+                <Label htmlFor="jailDurationSelect">
+                    Duration
+                </Label>
+                <div className="space-y-1">
+                    <Select
+                        onValueChange={setCurrentDuration}
+                        value={currentDuration}
+                        disabled={disabled}
+                    >
+                        <SelectTrigger id="jailDurationSelect" className="tracking-wide">
+                            <SelectValue placeholder="Select Duration" />
+                        </SelectTrigger>
+                        <SelectContent className="tracking-wide">
+                            <SelectItem value="custom" className="font-bold">Custom (set below)</SelectItem>
+                            <SelectItem value="15 minutes">15 MINUTES</SelectItem>
+                            <SelectItem value="30 minutes">30 MINUTES</SelectItem>
+                            <SelectItem value="1 hours">1 HOUR</SelectItem>
+                            <SelectItem value="2 hours">2 HOURS</SelectItem>
+                            <SelectItem value="8 hours">8 HOURS</SelectItem>
+                        </SelectContent>
+                    </Select>
+                    <div className="flex flex-row gap-2">
+                        <Input
+                            id="jailDurationMultiplier"
+                            type="number"
+                            placeholder="123"
+                            required
+                            disabled={currentDuration !== 'custom' || disabled}
+                            ref={customMultiplierRef}
+                        />
+                        <Select
+                            onValueChange={setCustomUnits}
+                            value={customUnits}
+                        >
+                            <SelectTrigger
+                                className="tracking-wide"
+                                id="jailDurationUnits"
+                                disabled={currentDuration !== 'custom' || disabled}
+                            >
+                                <SelectValue />
+                            </SelectTrigger>
+                            <SelectContent className="tracking-wide">
+                                <SelectItem value="minutes">MINUTES</SelectItem>
+                                <SelectItem value="hours">HOURS</SelectItem>
+                                <SelectItem value="days">DAYS</SelectItem>
+                            </SelectContent>
+                        </Select>
+                    </div>
+                </div>
+                <p className="text-sm text-muted-foreground">
+                    The time only counts while the player is online. If they disconnect, the countdown resumes when they rejoin.
+                </p>
+            </div>
+        </div>
+    );
+});

--- a/panel/src/layout/ActionModal/ActionInfoTab.tsx
+++ b/panel/src/layout/ActionModal/ActionInfoTab.tsx
@@ -65,6 +65,19 @@ export default function ActionInfoTab({ action, serverTime, tsFetch }: ActionInf
         }
     }
 
+    let jailStatusText: React.ReactNode;
+    if (action.type === 'jail') {
+        const durationText = msToDuration(action.duration * 1000, { units: ['d', 'h', 'm'] });
+        if (action.served >= action.duration) {
+            jailStatusText = <span className="opacity-75">Fully served ({durationText})</span>;
+        } else {
+            const servedText = msToDuration(action.served * 1000, { units: ['d', 'h', 'm'] });
+            jailStatusText = <span className="text-warning-inline">
+                Served {servedText} of {durationText} (only counts while online)
+            </span>;
+        }
+    }
+
     let warnAckedText: React.ReactNode;
     if (action.type === 'warn' && action.acked) {
         warnAckedText = <span className="opacity-75">Yes</span>;
@@ -122,6 +135,12 @@ export default function ActionInfoTab({ action, serverTime, tsFetch }: ActionInf
                     <div className="py-0.5 grid grid-cols-3 gap-4 px-0">
                         <dt className="text-sm font-medium leading-6 text-muted-foreground">Player Accepted</dt>
                         <dd className="text-sm leading-6 col-span-2 mt-0">{warnAckedText}</dd>
+                    </div>
+                )}
+                {action.type === 'jail' && (
+                    <div className="py-0.5 grid grid-cols-3 gap-4 px-0">
+                        <dt className="text-sm font-medium leading-6 text-muted-foreground">Time Served</dt>
+                        <dd className="text-sm leading-6 col-span-2 mt-0">{jailStatusText}</dd>
                     </div>
                 )}
                 <div className="py-0.5 grid grid-cols-3 gap-4 px-0">

--- a/panel/src/layout/ActionModal/ActionModal.tsx
+++ b/panel/src/layout/ActionModal/ActionModal.tsx
@@ -10,7 +10,6 @@ import { HistoryActionModalResp, HistoryActionModalSuccess } from "@shared/histo
 import ActionIdsTab from "./ActionIdsTab";
 import ActionInfoTab from "./ActionInfoTab";
 import ActionModifyTab from "./ActionModifyTab";
-import ActionDeleteTab from "./ActionDeleteTab";
 import { ModalContent, ModalTabMessage, ModalTabsList, ModalTabWrapper, type ModalTabInfo } from "@/components/modal-tabs";
 
 
@@ -120,7 +119,13 @@ export default function ActionModal() {
                 <span className="text-warning-inline font-mono mr-2">[{modalData.action.id}]</span>
                 Warned {displayName}
             </>;
-        } else {
+        } else if (modalData.action.type === 'jail') {
+            pageTitle = <>
+                <span className="text-info-inline font-mono mr-2">[{modalData.action.id}]</span>
+                Jailed {displayName}
+            </>;
+        }
+        else {
             throw new Error(`Unknown action type: ${modalData.action.type}`);
         }
     } else if (modalError) {

--- a/panel/src/layout/ActionModal/ActionModifyTab.tsx
+++ b/panel/src/layout/ActionModal/ActionModifyTab.tsx
@@ -40,7 +40,12 @@ export default function ActionModifyTab({ action, refreshModalData }: ActionModi
     }
 
     const isAlreadyRevoked = !!action.revocation.timestamp;
-    const hasRevokePerm = hasPerm(action.type === 'warn' ? 'players.warn' : 'players.ban');
+    const revokePermMap = {
+        warn: 'players.warn',
+        ban: 'players.ban',
+        jail: 'players.jail',
+    } as const;
+    const hasRevokePerm = hasPerm(revokePermMap[action.type] ?? 'players.ban');
     const revokeBtnLabel = isAlreadyRevoked
         ? `${action.type} revoked`
         : hasRevokePerm
@@ -54,6 +59,7 @@ export default function ActionModifyTab({ action, refreshModalData }: ActionModi
                     This is generally done when the player successfully appeals the {action.type} or the admin regrets issuing it.
                     <ul className="list-disc list-inside pt-1">
                         {action.type === 'ban' && <li>The player will be able to rejoin the server.</li>}
+                        {action.type === 'jail' && <li>The player will be released immediately if online.</li>}
                         <li>The player will not be notified of the revocation.</li>
                         <li>This {action.type} will not be removed from the player history.</li>
                         <li>The revocation cannot be undone!</li>

--- a/panel/src/layout/PlayerModal/PlayerHistoryTab.tsx
+++ b/panel/src/layout/PlayerModal/PlayerHistoryTab.tsx
@@ -1,5 +1,5 @@
 import { cn } from "@/lib/utils";
-import { tsToLocaleDateTimeString } from "@/lib/dateTime";
+import { msToDuration, tsToLocaleDateTimeString } from "@/lib/dateTime";
 import { PlayerHistoryItem } from "@shared/playerApiTypes";
 import InlineCode from "@/components/InlineCode";
 import { useOpenActionModal } from "@/hooks/actionModal";
@@ -20,11 +20,19 @@ function HistoryItem({ action, serverTime, modalOpener }: HistoryItemProps) {
     } else if (action.type === 'warn') {
         borderColorClass = 'border-warning';
         actionMessage = `WARNED by ${action.author}`;
+    } else if (action.type === 'jail') {
+        borderColorClass = 'border-info';
+        actionMessage = `JAILED by ${action.author}`;
     }
     if (action.revokedBy) {
         borderColorClass = '';
         const revocationDate = tsToLocaleDateTimeString(action.revokedAt ?? 0, 'medium', 'short');
         footerNote = `Revoked by ${action.revokedBy} on ${revocationDate}.`;
+    } else if (action.type === 'jail' && typeof action.duration === 'number') {
+        const served = action.served ?? 0;
+        footerNote = served >= action.duration
+            ? `Sentence of ${msToDuration(action.duration * 1000)} fully served.`
+            : `Served ${msToDuration(served * 1000)} of ${msToDuration(action.duration * 1000)}.`;
     } else if (typeof action.exp === 'number') {
         const expirationDate = tsToLocaleDateTimeString(action.exp, 'medium', 'short');
         footerNote = (action.exp < serverTime) ? `Expired on ${expirationDate}.` : `Expires in ${expirationDate}.`;

--- a/panel/src/layout/PlayerModal/PlayerInfoTab.tsx
+++ b/panel/src/layout/PlayerModal/PlayerInfoTab.tsx
@@ -14,7 +14,7 @@ import { useMemo, useRef, useState } from "react";
 import { ModalTabInner } from "@/components/modal-tabs";
 
 
-function LogActionCounter({ type, count }: { type: 'Ban' | 'Warn', count: number }) {
+function LogActionCounter({ type, count }: { type: 'Ban' | 'Warn' | 'Jail', count: number }) {
     const pluralLabel = (count > 1) ? `${type}s` : type;
     if (count === 0) {
         return <span className={cn(
@@ -26,7 +26,7 @@ function LogActionCounter({ type, count }: { type: 'Ban' | 'Warn', count: number
     } else {
         return <span className={cn(
             'h-max rounded-sm text-xs font-semibold px-1 py-[0.125rem] tracking-widest text-center inline-block',
-            type === 'Ban' ? 'bg-destructive text-destructive-foreground' : 'bg-warning text-warning-foreground'
+            type === 'Ban' ? 'bg-destructive text-destructive-foreground' : type === 'Jail' ? 'bg-info text-info-foreground' : 'bg-warning text-warning-foreground'
         )}>
             {count} {pluralLabel}
         </span>
@@ -158,6 +158,7 @@ export default function PlayerInfoTab({ playerRef, player, serverTime, tsFetch, 
     />;
     const banCount = player.actionHistory.filter((a) => a.type === 'ban' && !a.revokedAt).length;
     const warnCount = player.actionHistory.filter((a) => a.type === 'warn' && !a.revokedAt).length;
+    const jailCount = player.actionHistory.filter((a) => a.type === 'jail' && !a.revokedAt).length;
 
     const handleWhitelistClick = () => {
         playerWhitelistApi({
@@ -197,6 +198,19 @@ export default function PlayerInfoTab({ playerRef, player, serverTime, tsFetch, 
         }
     }, [player, serverTime]);
 
+    const playerJailedText: string | undefined = useMemo(() => {
+        if (!player) return;
+        for (const action of player.actionHistory) {
+            if (action.type !== 'jail' || action.revokedAt) continue;
+            if (typeof action.duration !== 'number') continue;
+            const served = action.served ?? 0;
+            const remaining = action.duration - served;
+            if (remaining > 0) {
+                return `This player is jailed for remaining ${msToDuration(remaining * 1000)}`;
+            }
+        }
+    }, [player]);
+
     return (
         <ModalTabInner>
             {playerBannedText ? (
@@ -206,6 +220,16 @@ export default function PlayerInfoTab({ playerRef, player, serverTime, tsFetch, 
                     </div>
                     <div className="flex-grow text-sm font-medium">
                         {playerBannedText}
+                    </div>
+                </div>
+            ) : null}
+            {playerJailedText ? (
+                <div className="w-full p-2 pr-3 mb-1 flex items-center justify-between space-x-4 rounded-lg border shadow-lg transition-all text-black/75 dark:text-white/90 border-info/70 bg-info-hint">
+                    <div className="flex-shrink-0 flex flex-col gap-2 items-center">
+                        <ShieldAlertIcon className="size-5 text-info" />
+                    </div>
+                    <div className="flex-grow text-sm font-medium">
+                        {playerJailedText}
                     </div>
                 </div>
             ) : null}
@@ -247,6 +271,7 @@ export default function PlayerInfoTab({ playerRef, player, serverTime, tsFetch, 
                     <dd className="text-sm leading-6 mt-0 flex flex-wrap gap-2">
                         <LogActionCounter type="Ban" count={banCount} />
                         <LogActionCounter type="Warn" count={warnCount} />
+                        <LogActionCounter type="Jail" count={jailCount} />
                     </dd>
                     <dd className="text-right">
                         <Button

--- a/panel/src/layout/PlayerModal/PlayerJailTab.tsx
+++ b/panel/src/layout/PlayerModal/PlayerJailTab.tsx
@@ -1,0 +1,79 @@
+import { Button } from "@/components/ui/button";
+import { useAdminPerms } from "@/hooks/auth";
+import { PlayerModalRefType, useClosePlayerModal } from "@/hooks/playerModal";
+import { Loader2Icon } from "lucide-react";
+import { useRef, useState } from "react";
+import { useBackendApi } from "@/hooks/fetch";
+import { GenericApiOkResp } from "@shared/genericApiTypes";
+import JailForm, { JailFormType } from "@/components/JailForm";
+import { txToast } from "@/components/TxToaster";
+import { ModalTabInner, ModalTabMessage } from "@/components/modal-tabs";
+
+
+type PlayerJailTabProps = {
+    playerRef: PlayerModalRefType;
+};
+
+export default function PlayerJailTab({ playerRef }: PlayerJailTabProps) {
+    const jailFormRef = useRef<JailFormType>(null);
+    const [isSaving, setIsSaving] = useState(false);
+    const { hasPerm } = useAdminPerms();
+    const closeModal = useClosePlayerModal();
+    const playerJailApi = useBackendApi<GenericApiOkResp>({
+        method: 'POST',
+        path: `/player/jail`,
+        throwGenericErrors: true,
+    });
+
+    if (!hasPerm('players.jail')) {
+        return <ModalTabMessage>
+            You don't have permission to jail players.
+        </ModalTabMessage>;
+    }
+
+    const handleSave = () => {
+        if (!jailFormRef.current) return;
+        const { reason, duration } = jailFormRef.current.getData();
+
+        if (!reason || reason.length < 3) {
+            txToast.warning(`The reason must be at least 3 characters long.`);
+            jailFormRef.current.focusReason();
+            return;
+        }
+
+        setIsSaving(true);
+        playerJailApi({
+            queryParams: playerRef,
+            data: { reason, duration },
+            toastLoadingMessage: 'Jailing player...',
+            genericHandler: {
+                successMsg: 'Player jailed.',
+            },
+            finally: () => setIsSaving(false),
+            success: () => closeModal(),
+        });
+    };
+
+    return (
+        <ModalTabInner className="grid gap-4">
+            <JailForm
+                ref={jailFormRef}
+                disabled={isSaving}
+            />
+            <div className="flex place-content-end">
+                <Button
+                    size="sm"
+                    variant="warning"
+                    disabled={isSaving}
+                    onClick={handleSave}
+                >
+                    {isSaving ? (
+                        <span className="flex items-center leading-relaxed">
+                            <Loader2Icon className="inline animate-spin h-4" /> Jailing...
+                        </span>
+                    ) : 'Apply Jail'}
+                </Button>
+            </div>
+        </ModalTabInner>
+    );
+}

--- a/panel/src/layout/PlayerModal/PlayerModal.tsx
+++ b/panel/src/layout/PlayerModal/PlayerModal.tsx
@@ -1,12 +1,13 @@
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { setPlayerModalUrlParam, usePlayerModalStateValue } from "@/hooks/playerModal";
-import { InfoIcon, ListIcon, HistoryIcon, GavelIcon } from "lucide-react";
+import { InfoIcon, ListIcon, HistoryIcon, GavelIcon, HourglassIcon } from "lucide-react";
 import PlayerInfoTab from "./PlayerInfoTab";
 import { useEffect, useState } from "react";
 import PlayerIdsTab from "./PlayerIdsTab";
 import PlayerHistoryTab from "./PlayerHistoryTab";
 import PlayerBanTab from "./PlayerBanTab";
+import PlayerJailTab from "./PlayerJailTab";
 import GenericSpinner from "@/components/GenericSpinner";
 import { cn } from "@/lib/utils";
 import { useBackendApi } from "@/hooks/fetch";
@@ -27,6 +28,11 @@ const modalTabs: ModalTabInfo[] = [
     {
         title: 'IDs',
         icon: <ListIcon className="mr-2 h-5 w-5 hidden xs:block" />,
+    },
+    {
+        title: 'Jail',
+        icon: <HourglassIcon className="mr-2 h-5 w-5 hidden xs:block" />,
+        className: 'hover:bg-warning hover:text-warning-foreground',
     },
     {
         title: 'Ban',
@@ -188,6 +194,9 @@ export default function PlayerModal() {
                                     player={modalData.player}
                                     playerRef={playerRef!}
                                     refreshModalData={refreshModalData}
+                                />}
+                                {selectedTab === 'Jail' && <PlayerJailTab
+                                    playerRef={playerRef!}
                                 />}
                                 {selectedTab === 'Ban' && <PlayerBanTab
                                     banTemplates={modalData.banTemplates}

--- a/panel/src/pages/History/HistoryPage.tsx
+++ b/panel/src/pages/History/HistoryPage.tsx
@@ -1,5 +1,5 @@
 import { memo, useCallback, useEffect, useMemo, useState } from 'react';
-import { AlertTriangleIcon, GavelIcon } from 'lucide-react';
+import { AlertTriangleIcon, FlagIcon, GavelIcon, LockIcon } from 'lucide-react';
 import PageCalloutRow, { PageCalloutProps } from '@/components/PageCalloutRow';
 import {
     HistorySearchBox,
@@ -102,20 +102,21 @@ export default function HistoryPage() {
                 icon: <AlertTriangleIcon />,
             },
             {
-                label: 'New Warns Last 7d',
-                value: hasCalloutData ? calloutData.warnsLast7d : false,
-                icon: <AlertTriangleIcon />,
-                prefix: '+'
-            },
-            {
                 label: 'Total Bans',
                 value: hasCalloutData ? calloutData.totalBans : false,
                 icon: <GavelIcon />,
             },
             {
-                label: 'New Bans Last 7d',
-                value: hasCalloutData ? calloutData.bansLast7d : false,
-                icon: <GavelIcon />,
+                label: 'Total Jails',
+                value: hasCalloutData ? calloutData.totalJails : false,
+                icon: <LockIcon />,
+            },
+            {
+                label: 'New Actions Last 7d',
+                value: hasCalloutData
+                    ? calloutData.warnsLast7d + calloutData.bansLast7d + calloutData.jailsLast7d
+                    : false,
+                icon: <FlagIcon />,
                 prefix: '+'
             }
         ] satisfies PageCalloutProps[];

--- a/panel/src/pages/History/HistorySearchBox.tsx
+++ b/panel/src/pages/History/HistorySearchBox.tsx
@@ -219,6 +219,9 @@ export function HistorySearchBox({ doSearch, initialState, adminStats }: History
                             <SelectItem value={'warn'} className="cursor-pointer">
                                 Warns
                             </SelectItem>
+                            <SelectItem value={'jail'} className="cursor-pointer">
+                                Jails
+                            </SelectItem>
                         </SelectContent>
                     </Select>
 

--- a/panel/src/pages/History/HistoryTable.tsx
+++ b/panel/src/pages/History/HistoryTable.tsx
@@ -5,7 +5,7 @@ import TxAnchor from '@/components/TxAnchor';
 import { cn } from '@/lib/utils';
 import { convertRowDateTime } from '@/lib/dateTime';
 import { TableBody, TableCell, TableHeader, TableRow } from "@/components/ui/table";
-import { Loader2Icon, GavelIcon, AlertTriangleIcon, Undo2Icon, TimerOffIcon, TimerIcon, HourglassIcon } from 'lucide-react';
+import { Loader2Icon, GavelIcon, AlertTriangleIcon, Undo2Icon, TimerOffIcon, TimerIcon, HourglassIcon, LockIcon } from 'lucide-react';
 import { useBackendApi } from '@/hooks/fetch';
 import { HistoryTableActionType, HistoryTableSearchResp, HistoryTableSearchType, HistoryTableSortingType } from '@shared/historyApiTypes';
 import { useOpenActionModal } from '@/hooks/actionModal';
@@ -38,6 +38,11 @@ function HistoryRow({ action, modalOpener }: HistoryRowProps) {
             <GavelIcon className='size-5' />
         </div>
         rowId = <span className='tracking-wider text-destructive'>{action.id}</span>
+    } else if (action.type === 'jail') {
+        rowPrefix = <div className='flex items-center px-1 bg-info-hint text-info'>
+            <LockIcon className='size-5' />
+        </div>
+        rowId = <span className='tracking-wider text-info'>{action.id}</span>
     } else {
         throw new Error(`Invalid action type: ${action.type}`);
     }
@@ -52,6 +57,8 @@ function HistoryRow({ action, modalOpener }: HistoryRowProps) {
         } else if (action.banExpiration === 'active') {
             statusIcon = <TimerIcon className='size-4' />;
         }
+    } else if (action.jailStatus === 'active') {
+        statusIcon = <TimerIcon className='size-4' />;
     } else if (action.type === 'warn' && !action.warnAcked) {
         statusIcon = <HourglassIcon className='size-4' />;
     }

--- a/panel/src/pages/Settings/tabCards/gameMenu.tsx
+++ b/panel/src/pages/Settings/tabCards/gameMenu.tsx
@@ -5,6 +5,7 @@ import { AdvancedDivider, SettingItem, SettingItemDesc } from '../settingsItems'
 import { useState, useEffect, useMemo, useReducer } from "react";
 import { getConfigEmptyState, getConfigAccessors, SettingsCardProps, getPageConfig, configsReducer, getConfigDiff } from "../utils";
 import SettingsCardShell from "../SettingsCardShell";
+import { txToast } from "@/components/TxToaster";
 
 
 export const pageConfigs = {
@@ -12,7 +13,12 @@ export const pageConfigs = {
     alignRight: getPageConfig('gameFeatures', 'menuAlignRight'),
     pageKey: getPageConfig('gameFeatures', 'menuPageKey'),
     playerModePtfx: getPageConfig('gameFeatures', 'playerModePtfx'),
+    jailRoutingBucket: getPageConfig('gameFeatures', 'jailRoutingBucket', true),
+    jailPosFivem: getPageConfig('gameFeatures', 'jailPosFivem', true),
+    jailPosRedm: getPageConfig('gameFeatures', 'jailPosRedm', true),
 } as const;
+
+const coordsRegex = /^-?\d+(\.\d+)?\s*,\s*-?\d+(\.\d+)?\s*,\s*-?\d+(\.\d+)?$/;
 
 export default function ConfigCardGameMenu({ cardCtx, pageCtx }: SettingsCardProps) {
     const [showAdvanced, setShowAdvanced] = useState(false);
@@ -49,7 +55,15 @@ export default function ConfigCardGameMenu({ cardCtx, pageCtx }: SettingsCardPro
     const handleOnSave = () => {
         const { hasChanges, localConfigs } = updatePageState();
         if (!hasChanges) return;
-        //NOTE: nothing to validate
+        for (const cfgName of ['jailPosFivem', 'jailPosRedm'] as const) {
+            const value = localConfigs.gameFeatures?.[cfgName];
+            if (value !== undefined && !coordsRegex.test(value)) {
+                return txToast.error({
+                    title: 'Invalid jail position.',
+                    msg: 'The coordinates must be in the "x, y, z" format.',
+                });
+            }
+        }
         pageCtx.saveChanges(cardCtx, localConfigs);
     }
 
@@ -132,6 +146,47 @@ export default function ConfigCardGameMenu({ cardCtx, pageCtx }: SettingsCardPro
                 <SettingItemDesc>
                     Play a particle effect and sound when an admin uses NoClip, God Mode, etc. <br />
                     <strong className="text-warning-inline">Warning:</strong> This options help prevent admin abuse during PvP by making it visible/audible to all players that an admin is using a special mode. We recommend keeping it enabled.
+                </SettingItemDesc>
+            </SettingItem>
+            <SettingItem label="Jail Routing Bucket" htmlFor={cfg.jailRoutingBucket.eid} showIf={showAdvanced} required>
+                <Input
+                    id={cfg.jailRoutingBucket.eid}
+                    type="number"
+                    min={1}
+                    max={1023}
+                    value={states.jailRoutingBucket ?? ''}
+                    onChange={(e) => cfg.jailRoutingBucket.state.set(parseInt(e.target.value) || undefined)}
+                    disabled={pageCtx.isReadOnly}
+                />
+                <SettingItemDesc>
+                    The routing bucket (dimension) that jailed players are moved to, isolating them from everyone else. <br />
+                    <strong>Note:</strong> Make sure no other resource uses this bucket number.
+                </SettingItemDesc>
+            </SettingItem>
+            <SettingItem label="Jail Position (FiveM)" htmlFor={cfg.jailPosFivem.eid} showIf={showAdvanced} required>
+                <Input
+                    id={cfg.jailPosFivem.eid}
+                    value={states.jailPosFivem ?? ''}
+                    placeholder='459.28, -1001.85, 24.91'
+                    onChange={(e) => cfg.jailPosFivem.state.set(e.target.value)}
+                    className="font-mono"
+                    disabled={pageCtx.isReadOnly}
+                />
+                <SettingItemDesc>
+                    The coordinates (<InlineCode>x, y, z</InlineCode>) jailed players are teleported to on FiveM servers. The default is a Mission Row PD cell.
+                </SettingItemDesc>
+            </SettingItem>
+            <SettingItem label="Jail Position (RedM)" htmlFor={cfg.jailPosRedm.eid} showIf={showAdvanced} required>
+                <Input
+                    id={cfg.jailPosRedm.eid}
+                    value={states.jailPosRedm ?? ''}
+                    placeholder='-276.0, 806.0, 119.38'
+                    onChange={(e) => cfg.jailPosRedm.state.set(e.target.value)}
+                    className="font-mono"
+                    disabled={pageCtx.isReadOnly}
+                />
+                <SettingItemDesc>
+                    The coordinates (<InlineCode>x, y, z</InlineCode>) jailed players are teleported to on RedM servers. The default is a Valentine sheriff cell.
                 </SettingItemDesc>
             </SettingItem>
         </SettingsCardShell>

--- a/resource/cl_jail.lua
+++ b/resource/cl_jail.lua
@@ -1,0 +1,110 @@
+-- =============================================
+--  This file handles the client-side jail (timeout) enforcement:
+--  teleporting + freezing the ped, keeping it inside the jail,
+--  and showing the countdown alert.
+--  NOTE: must work with the menu disabled, so it only uses the
+--  helpers from cl_functions.lua that are always available.
+-- =============================================
+
+local isJailed = false
+local jailPos = nil
+local jailRemaining = 0
+local originalCoords = nil
+
+--- Opens/updates the full-screen jail overlay in the NUI.
+--- Only needs to be called on start and whenever the displayed minute
+--- changes, since the NUI ticks the countdown down locally every second.
+local function updateJailScreen(author, reason)
+    sendMenuMessage('setJailOpen', {
+        author = author,
+        reason = reason,
+        remainingSeconds = jailRemaining,
+    })
+end
+
+local function enforceJailPosition()
+    local playerPed = PlayerPedId()
+    TaskLeaveAnyVehicle(playerPed, 0, 16)
+    Wait(50)
+    playerPed = PlayerPedId()
+    SetEntityCoords(playerPed, jailPos.x, jailPos.y, jailPos.z, false, false, false, false)
+    FreezeEntityPosition(playerPed, true)
+end
+
+--- Disables all control inputs (movement, combat, vehicles, weapon wheel, etc.)
+--- every frame while jailed, so freezing alone can't be bypassed.
+local function startInputBlockThread()
+    CreateThread(function()
+        while isJailed do
+            DisableAllControlActions(0)
+            DisableAllControlActions(1)
+            DisableAllControlActions(2)
+            DisablePlayerFiring(PlayerId(), true)
+            Wait(0)
+        end
+    end)
+end
+
+RegisterNetEvent('txcl:jail:start', function(author, reason, remaining, pos)
+    if type(remaining) ~= 'number' or type(pos) ~= 'table' then return end
+    local wasJailed = isJailed
+    isJailed = true
+    jailPos = vector3(pos.x, pos.y, pos.z)
+    jailRemaining = remaining
+
+    -- save the original position to restore on release (first jail this session only)
+    if not wasJailed then
+        originalCoords = GetEntityCoords(PlayerPedId())
+    end
+
+    enforceJailPosition()
+    updateJailScreen(author, reason)
+
+    if wasJailed then return end --enforcement thread already running
+
+    startInputBlockThread()
+
+    CreateThread(function()
+        local lastUpdateMinute = math.ceil(jailRemaining / 60)
+        while isJailed do
+            Wait(1000)
+            if not isJailed then break end
+            jailRemaining = jailRemaining - 1
+
+            -- re-enforce position/freeze (death respawns recreate the ped)
+            local playerPed = PlayerPedId()
+            if not IsEntityDead(playerPed) then
+                if #(GetEntityCoords(playerPed) - jailPos) > 10.0 then
+                    enforceJailPosition()
+                else
+                    FreezeEntityPosition(playerPed, true) --idempotent, counters other scripts unfreezing
+                end
+            end
+
+            SetEntityHealth(playerPed, GetEntityMaxHealth(playerPed))
+
+            -- resync the NUI countdown when the displayed minute changes
+            local currMinute = math.ceil(jailRemaining / 60)
+            if currMinute ~= lastUpdateMinute then
+                lastUpdateMinute = currMinute
+                updateJailScreen(author, reason)
+            end
+        end
+    end)
+end)
+
+RegisterNetEvent('txcl:jail:release', function()
+    if not isJailed then return end
+    isJailed = false
+    jailPos = nil
+
+    local playerPed = PlayerPedId()
+    FreezeEntityPosition(playerPed, false)
+    if originalCoords ~= nil then
+        SetEntityCoords(playerPed, originalCoords.x, originalCoords.y, originalCoords.z, false, false, false, false)
+        originalCoords = nil
+    end
+
+    sendMenuMessage('closeJail', {})
+    sendSnackbarMessage('info', 'nui_menu.jail.released', true)
+end)

--- a/resource/menu/client/cl_functions.lua
+++ b/resource/menu/client/cl_functions.lua
@@ -9,9 +9,10 @@
 ---@param level string The level for the alert
 ---@param message string The message for this alert
 ---@param isTranslationKey boolean Whether the message is a translation key
-function sendPersistentAlert(key, level, message, isTranslationKey)
+---@param tOptions table | nil Translation interpolation options
+function sendPersistentAlert(key, level, message, isTranslationKey, tOptions)
     debugPrint(('Sending persistent alert, key: %s, level: %s, message: %s'):format(key, level, message))
-    sendMenuMessage('setPersistentAlert', { key = key, level = level, message = message, isTranslationKey = isTranslationKey })
+    sendMenuMessage('setPersistentAlert', { key = key, level = level, message = message, isTranslationKey = isTranslationKey, tOptions = tOptions })
 end
 
 --- Clear a persistent alert on screen

--- a/resource/sv_initialData.lua
+++ b/resource/sv_initialData.lua
@@ -52,6 +52,11 @@ local function useInitData(data)
             targetName = data.pendingWarn.targetName,
         }, false)
     end
+    if data.pendingJail ~= nil then
+        -- parity with the txaEvent dispatcher public passthrough
+        TriggerEvent('txAdmin:events:playerJailed', data.pendingJail)
+        TX_EVENT_HANDLERS.playerJailed(data.pendingJail, false)
+    end
 end
 
 RegisterCommand('txaInitialData', function(source, args)

--- a/resource/sv_jail.lua
+++ b/resource/sv_jail.lua
@@ -42,8 +42,8 @@ local function releasePlayer(netidStr, reason)
         jailReturnBuckets[jailData.returnKey] = nil
     end
 
-    if DoesPlayerExist(netidStr) then
-        SetPlayerRoutingBucket(netidStr, prevRoutBucket or 0)
+    if netid and DoesPlayerExist(netid) then
+        SetPlayerRoutingBucket(netid, prevRoutBucket or 0)
         Player(netid).state:set('txAdminJailed', nil, true)
         TriggerClientEvent('txcl:jail:release', netid)
     end
@@ -70,24 +70,24 @@ end
 --- Moves the target player to the jail bucket, teleports and freezes them
 TX_EVENT_HANDLERS.playerJailed = function(eventData, isNew)
     if eventData.targetNetId == nil then return end
-    local netidStr = tostring(eventData.targetNetId)
-    if not DoesPlayerExist(netidStr) then
+    local netid = tonumber(eventData.targetNetId)
+    if not netid or not DoesPlayerExist(netid) then
         txPrint(('[playerJailed] ignoring jail for disconnected player (#%s) %s'):format(
-            netidStr,
+            tostring(eventData.targetNetId),
             tostring(eventData.targetName)
         ))
         return
     end
+    local netidStr = tostring(netid)
 
-    local netid = eventData.targetNetId
     local pos = IS_REDM and eventData.posRedm or eventData.posFivem
 
     -- move to the jail routing bucket, saving the current one
     local returnKey = getReturnKey(eventData.targetIds)
     if returnKey ~= nil and jailReturnBuckets[returnKey] == nil then
-        jailReturnBuckets[returnKey] = GetPlayerRoutingBucket(netidStr)
+        jailReturnBuckets[returnKey] = GetPlayerRoutingBucket(netid)
     end
-    SetPlayerRoutingBucket(netidStr, eventData.bucket)
+    SetPlayerRoutingBucket(netid, eventData.bucket)
 
     -- public statebag so other resources can detect the jailed status
     Player(netid).state:set('txAdminJailed', {
@@ -144,16 +144,20 @@ CreateThread(function()
         local doStatebagSync = statebagSyncCounter >= 15
         if doStatebagSync then statebagSyncCounter = 0 end
 
+        local toRelease = {}
         for netidStr, jailData in pairs(jailedPlayers) do
             jailData.remaining = jailData.remaining - 1
             if jailData.remaining <= 0 then
-                releasePlayer(netidStr, 'completed')
-            elseif doStatebagSync and DoesPlayerExist(netidStr) then
+                toRelease[#toRelease + 1] = netidStr
+            elseif doStatebagSync and DoesPlayerExist(tonumber(netidStr)) then
                 Player(tonumber(netidStr)).state:set('txAdminJailed', {
                     actionId = jailData.actionId,
                     remaining = jailData.remaining,
                 }, true)
             end
+        end
+        for i = 1, #toRelease do
+            releasePlayer(toRelease[i], 'completed')
         end
     end
 end)

--- a/resource/sv_jail.lua
+++ b/resource/sv_jail.lua
@@ -1,0 +1,170 @@
+-- Prevent running in monitor mode
+if not TX_SERVER_MODE then return end
+
+-- =============================================
+--  This file handles the jail (timeout) punishment enforcement:
+--  isolating the player in a routing bucket, counting down the
+--  sentence, and releasing on completion or revocation.
+-- =============================================
+
+local cvHideAdminInPunishments = GetConvarBool('txAdmin-hideAdminInPunishments')
+local txServerName = GetConvar("txAdmin-serverName", "txAdmin")
+
+--- Runtime state of currently jailed players, keyed by netid string
+--- { actionId, remaining, reason, author, returnKey }
+local jailedPlayers = {}
+
+local jailReturnBuckets = {}
+
+local function getReturnKey(targetIds)
+    if type(targetIds) ~= 'table' then return nil end
+    for _, id in ipairs(targetIds) do
+        if type(id) == 'string' and id:sub(1, 8) == 'license:' then
+            return id
+        end
+    end
+    return nil
+end
+
+
+--- Releases a player from jail, restoring their routing bucket
+---@param netidStr string
+---@param reason string 'completed' or 'revoked'
+local function releasePlayer(netidStr, reason)
+    local jailData = jailedPlayers[netidStr]
+    if jailData == nil then return end
+    jailedPlayers[netidStr] = nil
+    local netid = tonumber(netidStr)
+
+    local prevRoutBucket
+    if jailData.returnKey ~= nil then
+        prevRoutBucket = jailReturnBuckets[jailData.returnKey]
+        jailReturnBuckets[jailData.returnKey] = nil
+    end
+
+    if DoesPlayerExist(netidStr) then
+        SetPlayerRoutingBucket(netidStr, prevRoutBucket or 0)
+        Player(netid).state:set('txAdminJailed', nil, true)
+        TriggerClientEvent('txcl:jail:release', netid)
+    end
+
+    if reason == 'completed' then
+        PrintStructuredTrace(json.encode({
+            type = 'txAdminJailComplete',
+            actionId = jailData.actionId,
+            netId = netid,
+        }))
+    end
+
+    -- Public event so other resources (phone, jobs, etc.) can react
+    TriggerEvent('txAdmin:events:playerJailReleased', {
+        actionId = jailData.actionId,
+        netId = netid,
+        reason = reason,
+    })
+    txPrint(('Released player #%s from jail [%s] (%s)'):format(netidStr, jailData.actionId, reason))
+end
+
+
+--- Handler for the playerJailed event
+--- Moves the target player to the jail bucket, teleports and freezes them
+TX_EVENT_HANDLERS.playerJailed = function(eventData, isNew)
+    if eventData.targetNetId == nil then return end
+    local netidStr = tostring(eventData.targetNetId)
+    if not DoesPlayerExist(netidStr) then
+        txPrint(('[playerJailed] ignoring jail for disconnected player (#%s) %s'):format(
+            netidStr,
+            tostring(eventData.targetName)
+        ))
+        return
+    end
+
+    local netid = eventData.targetNetId
+    local pos = IS_REDM and eventData.posRedm or eventData.posFivem
+
+    -- move to the jail routing bucket, saving the current one
+    local returnKey = getReturnKey(eventData.targetIds)
+    if returnKey ~= nil and jailReturnBuckets[returnKey] == nil then
+        jailReturnBuckets[returnKey] = GetPlayerRoutingBucket(netidStr)
+    end
+    SetPlayerRoutingBucket(netidStr, eventData.bucket)
+
+    -- public statebag so other resources can detect the jailed status
+    Player(netid).state:set('txAdminJailed', {
+        actionId = eventData.actionId,
+        remaining = eventData.remaining,
+    }, true)
+
+    jailedPlayers[netidStr] = {
+        actionId = eventData.actionId,
+        remaining = eventData.remaining,
+        reason = eventData.reason,
+        author = eventData.author,
+        returnKey = returnKey,
+    }
+
+    local authorName = cvHideAdminInPunishments and txServerName or eventData.author or 'anonym'
+    TriggerClientEvent(
+        'txcl:jail:start',
+        netid,
+        authorName,
+        eventData.reason,
+        eventData.remaining,
+        pos
+    )
+    txPrint(('Jailing player (#%s) %s for %ds: %s'):format(
+        netidStr,
+        tostring(eventData.targetName),
+        eventData.remaining,
+        eventData.reason
+    ))
+end
+
+
+--- Handler for the actionRevoked event (registered as no-op in sv_main.lua)
+--- Releases the matching jailed player, if online
+TX_EVENT_HANDLERS.actionRevoked = function(eventData)
+    if eventData.actionType ~= 'jail' then return end
+    for netidStr, jailData in pairs(jailedPlayers) do
+        if jailData.actionId == eventData.actionId then
+            releasePlayer(netidStr, 'revoked')
+            return
+        end
+    end
+end
+
+
+-- Countdown thread: ticks the remaining time and releases at zero.
+-- Also refreshes the public statebag every ~15s.
+CreateThread(function()
+    local statebagSyncCounter = 0
+    while true do
+        Wait(1000)
+        statebagSyncCounter = statebagSyncCounter + 1
+        local doStatebagSync = statebagSyncCounter >= 15
+        if doStatebagSync then statebagSyncCounter = 0 end
+
+        for netidStr, jailData in pairs(jailedPlayers) do
+            jailData.remaining = jailData.remaining - 1
+            if jailData.remaining <= 0 then
+                releasePlayer(netidStr, 'completed')
+            elseif doStatebagSync and DoesPlayerExist(netidStr) then
+                Player(tonumber(netidStr)).state:set('txAdminJailed', {
+                    actionId = jailData.actionId,
+                    remaining = jailData.remaining,
+                }, true)
+            end
+        end
+    end
+end)
+
+
+-- Clear the runtime entry when a jailed player leaves.
+-- The served time is persisted by the txAdmin core on disconnect.
+AddEventHandler('playerDropped', function()
+    local srcStr = tostring(source)
+    if jailedPlayers[srcStr] ~= nil then
+        txPrint(('Player #%s left while jailed [%s]'):format(srcStr, jailedPlayers[srcStr].actionId))
+        jailedPlayers[srcStr] = nil
+    end
+end)

--- a/shared/historyApiTypes.ts
+++ b/shared/historyApiTypes.ts
@@ -6,6 +6,8 @@ export type HistoryStatsResp = {
     warnsLast7d: number;
     totalBans: number;
     bansLast7d: number;
+    totalJails: number;
+    jailsLast7d: number;
     groupedByAdmins: {
         name: string;
         actions: number;
@@ -38,7 +40,7 @@ export type HistoryTableReqType = {
 
 export type HistoryTableActionType = {
     id: string;
-    type: "ban" | "warn";
+    type: "ban" | "warn" | "jail";
     playerName: string | false;
     author: string;
     reason: string;
@@ -46,6 +48,7 @@ export type HistoryTableActionType = {
     isRevoked: boolean;
     banExpiration?: 'expired' | 'active' | 'permanent';
     warnAcked?: boolean;
+    jailStatus?: 'active' | 'served';
 }
 
 export type HistoryTableSearchResp = {

--- a/shared/playerApiTypes.ts
+++ b/shared/playerApiTypes.ts
@@ -4,11 +4,13 @@ import { BanTemplatesDataType } from "./otherTypes";
 //Already compliant with new db specs
 export type PlayerHistoryItem = {
     id: string;
-    type: "ban" | "warn";
+    type: "ban" | "warn" | "jail";
     author: string;
     reason: string;
     ts: number;
     exp?: number;
+    duration?: number; //jail only: total sentence in seconds
+    served?: number; //jail only: seconds served while online
     revokedBy?: string;
     revokedAt?: number;
 }


### PR DESCRIPTION
Adds a "jail" (timeout) action as an alternative to bans/kicks — instead of removing a player from the server, admins can now confine them in-game for a set duration.

- **Database**: new `jail` action type, with DAO methods to register a jail, add served time, and mark a sentence as finished. Served time only counts while the player is actually online, and it's clamped to the sentence duration. Jails can be revoked the same way bans/warns can.
- **Config**: added `jailRoutingBucket` (default `916`) and per-game jail coordinates (`jailPosFivem` / `jailPosRedm`, defaulting to Mission Row PD and the Valentine sheriff jail), both validated on input.
- **Enforcement**: new `jailUtils.ts` builds the "jail environment" (bucket + coords) sent to the client; wired through player classes, the player list, and FD3 message handling.
- **Client resources**: added `sv_jail.lua` and `cl_jail.lua` to actually enforce the jail in-game (routing bucket isolation + teleport).
- **UI**: new in-game jail overlay (`JailPage.tsx`, `DialogJailView.tsx`) and web panel form/tab (`JailForm.tsx`, `PlayerJailTab.tsx`) so admins can jail/release players and see jail history.
- **Events**: documented `playerJailed` (fires on apply and on re-apply after reconnect, carries bucket/coords/remaining time) and `playerJailReleased` (fires on completion or revocation) so other resources like phone/jobs scripts can react.
- **Permissions**: added a new `players.jail` permission.

## Why
Bans and kicks are often too harsh for minor infractions. Jail gives admins a lighter-touch option while still exposing enough events/state (`txAdminJailed` state bag) for other resources to hook int