### PR TITLE
Fix ban template reason textarea width

### DIFF
--- a/panel/src/pages/BanTemplates/BanTemplatesInputDialog.tsx
+++ b/panel/src/pages/BanTemplates/BanTemplatesInputDialog.tsx
@@ -111,27 +111,28 @@ export default function BanTemplatesInputDialog({
                             <DialogTitle>{reasonData ? 'Edit' : 'Add'} Template</DialogTitle>
                         </DialogHeader>
                         <div className="grid grid-cols-6 items-center gap-4">
-                            <Label htmlFor="banReason" className="col-span-6 sm:col-auto">
+                            <Label htmlFor="reason" className="col-span-6 sm:col-auto">
                                 Reason
                             </Label>
-                            <AutosizeTextarea
-                                id="reason"
-                                placeholder="The reason for the ban, rule violated, etc."
-                                className="col-span-full sm:col-span-5"
-                                defaultValue={initialReason}
-                                ref={reasonRef}
-                                maxHeight={160}
-                                minLength={3}
-                                autoFocus
-                                required
-                                onChangeCapture={(e) => {
-                                    //prevent breaking line
-                                    const target = e.target as HTMLInputElement;
-                                    if (target.value.includes('\n')) {
-                                        target.value = target.value.replace(/\s*\r*\n+\s*/g, ' ');
-                                    }
-                                }}
-                            />
+                            <div className="col-span-full sm:col-span-5">
+                                <AutosizeTextarea
+                                    id="reason"
+                                    placeholder="The reason for the ban, rule violated, etc."
+                                    defaultValue={initialReason}
+                                    ref={reasonRef}
+                                    maxHeight={160}
+                                    minLength={3}
+                                    autoFocus
+                                    required
+                                    onChangeCapture={(e) => {
+                                        //prevent breaking line
+                                        const target = e.target as HTMLInputElement;
+                                        if (target.value.includes('\n')) {
+                                            target.value = target.value.replace(/\s*\r*\n+\s*/g, ' ');
+                                        }
+                                    }}
+                                />
+                            </div>
                         </div>
                         <div className="grid grid-cols-6 items-center gap-4">
                             <Label htmlFor="durationSelect" className="col-span-6 sm:col-auto">


### PR DESCRIPTION
## Summary
Fixes the ban template dialog reason field not spanning the expected dialog width after the autosize textarea gained a wrapper element.

## Cause
The dialog passed grid column classes directly to `AutosizeTextarea`. Since the component now renders a wrapper around the textarea, those classes no longer applied to the grid child.

## Changes
- Move the grid span classes to a wrapper around `AutosizeTextarea`
- Fix the reason label `htmlFor` to match the textarea id